### PR TITLE
Update links to Windows VMs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Our latest updates make FLARE VM more open and maintainable to allow the communi
 ### Good to Know Now
 
 * Windows 7 is no longer supported
-* FLARE VM has been tested on [Windows 10 1809 x64](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/) and `20H2`
+* FLARE VM has been tested on [Windows 10 1809 x64](https://archive.org/details/modern.ie-vm) and `20H2`
 * Please do a fresh install instead of trying to update an older FLARE VM
 * The installer has a GUI and can also run in CLI-only mode
 * Contributing is encouraged!!
@@ -59,7 +59,7 @@ Our latest updates make FLARE VM more open and maintainable to allow the communi
 > **Note:** FLARE VM should ONLY be installed on a virtual machine!
 
 * Prepare a Windows 10+ virtual machine
-  * FLARE VM has been tested on [Windows 10 1809 x64](https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/) and `20H2`
+  * FLARE VM has been tested on [Windows 10 1809 x64](https://archive.org/details/modern.ie-vm) and `20H2`
   * We recommend:
     * Avoiding usernames containing a space or other special characters
     * Using a disk capacity of at least 70-80 GB and memory of at least 2 GB


### PR DESCRIPTION
Per the page at https://developer.microsoft.com/en-us/microsoft-edge/tools/vms/ - "The Microsoft Edge team no longer offers VM image downloads for the testing of Microsoft Edge and Internet Explorer." The page additionally suggests using an in-browser development environment for testing Edge/IE functionality, which doesn't accomplish FLARE-VM's mission.

These virtual machines were copied to and backed up at the following Internet Archive link: https://archive.org/details/modern.ie-vm - additionally there are alternatives suggested in https://github.com/mandiant/flare-vm/issues/434