### PR TITLE
Fix not detecting stock VMWare/Hyper-V installations.

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -188,8 +188,18 @@ if (-not $noChecks.IsPresent) {
     }
 
     # Check if system is a virtual machine
-    $virtualModels = @('VirtualBox', 'VMware Virtual Platform', 'Virtual Machine')
-    if ((Get-WmiObject win32_computersystem).model -notin $virtualModels) {
+    $virtualModels = @('VirtualBox', 'VMware', 'Virtual Machine', 'Hyper-V')
+    $computerSystemModel = (Get-WmiObject win32_computersystem).model
+    $isVirtualModel = $false
+    
+    foreach ($model in $virtualModels) {
+        if ($computerSystemModel.Contains($model)) {
+            $isVirtualModel = $true
+            break
+        }
+    }
+
+    if (!$isVirtualModel) {
         Write-Host "`t[!] You are not on a virual machine or have hardened your machine to not appear as a virtual machine" -ForegroundColor Red
         Write-Host "`t[!] Please do NOT install this on your host system as it can't be uninstalled completely" -ForegroundColor Red
         Write-Host "`t[!] ** Please only install on a virtual machine **" -ForegroundColor Red


### PR DESCRIPTION
While installing on my VM (VMWare Workstation 17 Pro, Windows 10 Pro 64-bit 22H2), I've noticed how the installer was thinking my VM is hardened.

![image](https://user-images.githubusercontent.com/3672466/216929229-14e1db7a-49c4-487c-b4e3-775f62ac137f.png)

In my case, the computer system model was `"VMWare20,1"` which wouldn't pass the string equation of `== "VMware Virtual Platform"` of course.

This PR fixes the bug by checking if the computer system model contains any of the specified models, as well as changing the string of VMware's model to `"VMware"` to ensure success in all cases.

In addition, I've also added Hyper-V's model.