### PR TITLE
config: remove pestudio

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -41,7 +41,6 @@
         <package name="pebear.vm"/>
         <package name="peid.vm"/>
         <package name="pesieve.vm"/>
-        <package name="pestudio.vm"/>
         <package name="processdump.vm"/>
         <package name="regshot.vm"/>
         <package name="rundotnetdll.vm"/>


### PR DESCRIPTION
pestudio uses a url that doesn't include the version and the package breaks with every update as the hash changes. As the tool is updated often, this packages fails to install often and confuses users.

Closes https://github.com/mandiant/flare-vm/issues/468