### PR TITLE
Add default packages

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -41,6 +41,7 @@
         <package name="pebear.vm"/>
         <package name="peid.vm"/>
         <package name="pesieve.vm"/>
+        <package name="pestudio.vm"/>
         <package name="processdump.vm"/>
         <package name="regshot.vm"/>
         <package name="rundotnetdll.vm"/>

--- a/config.xml
+++ b/config.xml
@@ -26,6 +26,7 @@
         <package name="fakenet-ng.vm"/>
         <package name="floss.vm"/>
         <package name="ghidra.vm"/>
+        <package name="goresym.vm"/>
         <package name="hashmyfiles.vm"/>
         <package name="hollowshunter.vm"/>
         <package name="hxd.vm"/>
@@ -34,8 +35,10 @@
         <package name="innoextract.vm"/>
         <package name="innounp.vm"/>
         <package name="libraries.python3.vm"/>
+        <package name="malware-jail.vm"/>
         <package name="map.vm"/>
         <package name="nasm.vm"/>
+        <package name="net-reactor-slayer.vm"/>
         <package name="notepadplusplus.vm"/>
         <package name="notepadpp.plugin.compare.vm"/>
         <package name="pebear.vm"/>
@@ -49,6 +52,7 @@
         <package name="shellcode_launcher.vm"/>
         <package name="sysinternals.vm"/>
         <package name="uniextract2.vm"/>
+        <package name="upx.vm"/>
         <package name="vcbuildtools.vm"/>
         <package name="windbg.vm"/>
         <package name="wireshark.vm"/>


### PR DESCRIPTION
Add pestudio and other packages recently added to [VM-Packages](https://github.com/mandiant/VM-Packages). 😄 

Regarding pestudio, see https://github.com/mandiant/VM-Packages/pull/471, thanks to marc ochsenmeier for providing the new URL that prevents the package to fail so that we can re-add the package. 💘 

@mr-tz am I missing any other package that should be in the default flare-vm installation? 🤔 