### PR TITLE
Add version checking and upgrade for the chocolatey

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -276,6 +276,11 @@ if (-not ($chocolateyVersionGood -and $boxstarterVersionGood)) {
 }
 Import-Module "${Env:ProgramData}\boxstarter\boxstarter.chocolatey\boxstarter.chocolatey.psd1" -Force
 
+# Update the chocolatey if running the old version
+if (-not ($chocolateyVersionGood)){
+    choco upgrade chocolatey
+}
+
 # Attempt to disable updates (i.e., windows updates and store updates)
 Write-Host "[+] Attempting to disable updates..."
 Disable-MicrosoftUpdate


### PR DESCRIPTION
Add version checking and upgrade for the chocolatey before the GUI showing up. It prevents logic errors since choco -r have different behaviours in the older chocolatey version.