### PR TITLE
Adding check for usernames with spaces 

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -226,6 +226,19 @@ if (-not $noChecks.IsPresent) {
     if ($response -notin @("y","Y")) {
         exit 1
     }
+
+    # Check for spaces in the username, exit if identified
+    Write-Host "[+] Checking for spaces in the username..."
+    $currentUsername = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    $extractedUsername = $currentUsername -replace '^.*\\'
+    if ($extractedUsername -match '\s') {
+        Write-Host "`t[!] Username '$extractedUsername' contains a space and will break installation." -ForegroundColor Red
+        Write-Host "`t[!] Exiting..." -ForegroundColor Red
+        Start-Sleep 3
+        exit 1
+    } else {
+        Write-Host "`t[+] Username '$extractedUsername' does not contain any spaces." -ForegroundColor Green
+    }
 }
 
 if (-not $noPassword.IsPresent) {


### PR DESCRIPTION
Adding a small check in the install script that will detect spaces in usernames and exit gracefully if one is identified:

Detecting a space and exiting:
![2023-08-24 13_48_16-go-101-win - VMware Workstation](https://github.com/mandiant/flare-vm/assets/57866415/cad0e12e-f305-4ee5-9c2a-2c6bd0d31333)

...and continuing with the installation if the username looks good:
![2023-08-24 13_45_51-go-101-win - VMware Workstation](https://github.com/mandiant/flare-vm/assets/57866415/a57809eb-636f-44e5-8601-c5793aec6c33)

... and this check is encapsulated in the block of the rest of the checks, so the `-noChecks` param will bypass it, even if the username is non-compliant:
![image](https://github.com/mandiant/flare-vm/assets/57866415/a5afb337-4a42-4f3c-acc2-ef6eb956f02f)


