### PR TITLE
Fix config - remove dnfile.vm & install tools in Desktop\Tools

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -2,8 +2,7 @@
 <config>
     <envs>
         <env name="VM_COMMON_DIR" value="%ProgramData%\_VM"/>
-        <env name="TOOL_LIST_DIR" value="%ProgramData%\Microsoft\Windows\Start Menu\Programs\Tools"/>
-        <env name="TOOL_LIST_SHORTCUT" value="%UserProfile%\Desktop\Tools.lnk"/>
+        <env name="TOOL_LIST_DIR" value="%UserProfile%\Desktop\Tools"/>
         <env name="RAW_TOOLS_DIR" value="%SystemDrive%\Tools"/>
     </envs>
     <packages>

--- a/config.xml
+++ b/config.xml
@@ -23,7 +23,6 @@
         <package name="didier-stevens-suite.vm"/>
         <package name="die.vm"/>
         <package name="dll-to-exe.vm"/>
-        <package name="dnfile.vm"/>
         <package name="dnlib.vm"/>
         <package name="dnspyex.vm"/>
         <package name="dotdumper.vm"/>


### PR DESCRIPTION
- dnfile is part of the libraries.python3.vm package. dnfile.vm does not exist.
- `TOOL_LIST_SHORTCUT` has been removed in https://github.com/mandiant/VM-Packages/pull/656. Install the tools shortcuts directly into `%UserProfile%\Desktop\Tools`.