### PR TITLE
Improve how we checks the installer dependencies

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -254,18 +254,15 @@ if (-not $noPassword.IsPresent) {
     }
 }
 
-# Check Chocolatey and Boxstarter versions
+# Check Boxstarter version
 $boxstarterVersionGood = $false
-$chocolateyVersionGood = $false
-if(${Env:ChocolateyInstall} -and (Test-Path "${Env:ChocolateyInstall}\bin\choco.exe")) {
-    $version = choco --version
-    $chocolateyVersionGood = [System.Version]$version -ge [System.Version]"2.0.0"
+if (${Env:ChocolateyInstall} -and (Test-Path "${Env:ChocolateyInstall}\bin\choco.exe")) {
     choco info -l -r "boxstarter" | ForEach-Object { $name, $version = $_ -split '\|' }
     $boxstarterVersionGood = [System.Version]$version -ge [System.Version]"3.0.2"
 }
 
-# Install Chocolatey and Boxstarter if needed
-if (-not ($chocolateyVersionGood -and $boxstarterVersionGood)) {
+# Install Boxstarter if needed
+if (-not $boxstarterVersionGood) {
     Write-Host "[+] Installing Boxstarter..." -ForegroundColor Cyan
     [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
     Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://boxstarter.org/bootstrapper.ps1'))
@@ -274,6 +271,13 @@ if (-not ($chocolateyVersionGood -and $boxstarterVersionGood)) {
     Start-Sleep -Milliseconds 500
 }
 Import-Module "${Env:ProgramData}\boxstarter\boxstarter.chocolatey\boxstarter.chocolatey.psd1" -Force
+
+# Check Chocolatey version
+$version = choco --version
+$chocolateyVersionGood = [System.Version]$version -ge [System.Version]"2.0.0"
+
+# Update Chocolatey if needed
+if (-not ($chocolateyVersionGood)) { choco upgrade chocolatey }
 
 # Attempt to disable updates (i.e., windows updates and store updates)
 Write-Host "[+] Attempting to disable updates..."

--- a/install.ps1
+++ b/install.ps1
@@ -178,6 +178,20 @@ if (-not $noChecks.IsPresent) {
         Write-Host "`t[+] Installing on Windows version $osVersion" -ForegroundColor Green
     }
 
+    # Check PowerShell version
+    Write-Host "[+] Checking if PowerShell version is compatible..."
+    $psVersion = $PSVersionTable.PSVersion
+    if ($psVersion -lt [System.Version]"5.0.0") {
+        Write-Host "`t[!] You are using PowerShell version $psVersion. This is an old version and you may experience errors" -ForegroundColor Red
+        Write-Host "[-] Do you still wish to proceed? (Y/N): " -ForegroundColor Yellow -NoNewline
+        $response = Read-Host
+        if ($response -notin @("y","Y")) {
+            exit 1
+        }
+    } else {
+        Write-Host "`t[+] Installing with PowerShell version $psVersion" -ForegroundColor Green
+    }
+
     # Check if host has enough disk space
     Write-Host "[+] Checking if host has enough disk space..."
     $disk = Get-PSDrive (Get-Location).Drive.Name

--- a/install.ps1
+++ b/install.ps1
@@ -271,20 +271,6 @@ if (-not ($chocolateyVersionGood -and $boxstarterVersionGood)) {
     Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://boxstarter.org/bootstrapper.ps1'))
     Get-Boxstarter -Force
 
-    # Fix verbosity issues with Boxstarter v3
-    # See: https://github.com/chocolatey/boxstarter/issues/501
-    $fileToFix = "${Env:ProgramData}\boxstarter\boxstarter.chocolatey\Chocolatey.ps1"
-    $offendingString = 'if ($val -is [string] -or $val -is [boolean]) {'
-    if ((Get-Content $fileToFix -raw) -contains $offendingString) {
-        $fixString = 'if ($val -is [string] -or $val -is [boolean] -or $val -is [system.management.automation.actionpreference]) {'
-        ((Get-Content $fileToFix -raw) -replace [regex]::escape($offendingString),$fixString) | Set-Content $fileToFix
-    }
-    $fileToFix = "${Env:ProgramData}\boxstarter\boxstarter.chocolatey\invoke-chocolatey.ps1"
-    $offendingString = 'Verbose           = $VerbosePreference'
-    if ((Get-Content $fileToFix -raw) -contains $offendingString) {
-        $fixString = 'Verbose           = ($global:VerbosePreference -eq "Continue")'
-        ((Get-Content $fileToFix -raw) -replace [regex]::escape($offendingString),$fixString) | Set-Content $fileToFix
-    }
     Start-Sleep -Milliseconds 500
 }
 Import-Module "${Env:ProgramData}\boxstarter\boxstarter.chocolatey\boxstarter.chocolatey.psd1" -Force


### PR DESCRIPTION
- Improve the way we check if the correct versions of Chocolatey and Boxstarter are installed. Note that Boxstarter only installs chocolatey if it is not installed and it doesn't upgrade it if it is already install. This means we were not ensuring that the correct Chocolatey version was installed.
- Remove fix for bug fixed in Boxstarter 3.0.1 as we are requiring 3.0.2.
- We know that there are issues with old versions of PowerShell. Windows comes with PowerShell >= 5. Check that PowerShell version is at least 5.

Closes https://github.com/mandiant/flare-vm/issues/501
Closes https://github.com/mandiant/flare-vm/issues/500