### PR TITLE
Improve checks

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -126,7 +126,10 @@ if (-not $noChecks.IsPresent) {
 
     # Check if host has been tested
     $osVersion = (Get-WmiObject -class Win32_OperatingSystem).BuildNumber
-    $testedVersions = @(19045, 17763, 19042)
+    # 17763: the version used by windows-2019 in GH actions
+    # 19045: https://www.microsoft.com/en-us/software-download/windows10ISO downloaded on April 25 2023.
+    # 20348: the version used by windows-2022 in GH actions
+    $testedVersions = @(17763, 19045, 20348)
     if ($osVersion -notin $testedVersions) {
         Write-Host "`t[!] Windows version $osVersion has not been tested. Tested versions: $($testedVersions -join ', ')" -ForegroundColor Yellow
         Write-Host "`t[+] You are welcome to continue, but may experience errors downloading or installing packages" -ForegroundColor Yellow


### PR DESCRIPTION
Perform checks in a more logical order, including:
- Check first the Powershell version as some of the code may not work otherwise. Exit instead of using `-notin` that was introduced in Powershell 3 (and some user had previously used to try to install FLARE-VM).
- Ask about the snapshot after verifying the rest of the checks.

Update and document the Windows versions used currently for testing.
![Screenshot 2023-10-13 at 15 59 35](https://github.com/mandiant/flare-vm/assets/16052290/e8d3abf2-8b31-4c51-a9a3-b2c20ad226be)
