### PR TITLE
Add .NET Framework 3.5 to default config

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -25,6 +25,7 @@
         <package name="dnlib.vm"/>
         <package name="dnspyex.vm"/>
         <package name="dotdumper.vm"/>
+        <package name="dotnet3.5"/> <!-- To run old .NET binaries -->
         <package name="explorersuite.vm"/>
         <package name="fakenet-ng.vm"/>
         <package name="floss.vm"/>


### PR DESCRIPTION
Some old .NET binaries require .NET Framework 3.5 to run.