### PR TITLE
config.xml: Hide the .lnk extension

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -129,6 +129,7 @@
         <registry-item name="Disable Windows Firewall (Standard Profile)" path="HKLM:\SOFTWARE\Policies\Microsoft\WindowsFirewall\StandardProfile" value="EnableFirewall" type="DWord" data="0" />
         <registry-item name="Add ZoomIt to Windows Start" path="HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\run" value="ZoomIt" type="String" data="C:\Tools\sysinternals\ZoomIt64.exe" />
         <registry-item name="Don't display ZoomIt GUI on login" path="HKCU:\Software\Sysinternals\ZoomIt" value="OptionsShown" type="DWord" data="1" />
+        <registry-item name="Hide the .lnk extension" path="HKCR:\lnkfile" value="NeverShowExt" type="String" data=""/>
         <!-- Set dark mode
         <registry-item name="Set Dark Mode on System" path="HKCU:\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize" value="SystemUsesLightTheme" type="DWord" data="0"/>
         <registry-item name="Set Dark Mode on Apps" path="HKCU:\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize" value="AppsUseLightTheme" type="DWord" data="0"/>


### PR DESCRIPTION
I find the `.lnk` extension in the Tools directory too noisy, as all the tools are shortcuts with this extension. Hide the `.lnk` extension by adding the `NeverShowExt` value to `HKCR:\lnkfile`.

Closes https://github.com/mandiant/flare-vm/issues/521