### PR TITLE
config.xml: Auto arrange Desktop icons

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -131,6 +131,7 @@
         <registry-item name="Add ZoomIt to Windows Start" path="HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\run" value="ZoomIt" type="String" data="C:\Tools\sysinternals\ZoomIt64.exe" />
         <registry-item name="Don't display ZoomIt GUI on login" path="HKCU:\Software\Sysinternals\ZoomIt" value="OptionsShown" type="DWord" data="1" />
         <registry-item name="Hide the .lnk extension" path="HKCR:\lnkfile" value="NeverShowExt" type="String" data=""/>
+        <registry-item name="Auto arrange Desktop icons" path="HKCU:\SOFTWARE\Microsoft\Windows\Shell\Bags\1\Desktop" value="FFlags" type="DWord" data="1075839525"/>
         <!-- Set dark mode
         <registry-item name="Set Dark Mode on System" path="HKCU:\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize" value="SystemUsesLightTheme" type="DWord" data="0"/>
         <registry-item name="Set Dark Mode on Apps" path="HKCU:\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize" value="AppsUseLightTheme" type="DWord" data="0"/>


### PR DESCRIPTION
After calling `VM-Clean-Up` (which calls `VM-Remove-DesktopFiles` that deletes desktop files/folders), the arrangement of the icons in the Desktop look ugly.
![Screenshot 2023-11-23 at 16 10 58](https://github.com/mandiant/flare-vm/assets/16052290/20f9f7b5-b6eb-49ec-aaf2-fba6cca44c80)


Enable arrange Desktop icons using the registry to fix it. This will allow us to build the VM automatically without any manual interaction after running `VM-Clean-Up`.