### PR TITLE
[installer] Fix bug with Desktop\config.xml

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -92,9 +92,9 @@ function Get-ConfigFile {
             Write-Host "`t[!] $_"
         }
     } else {
-        # If the source exists as a file, copy it to the destination.
+        # If the source exists as a file, move it to the destination.
         Write-Host "[+] Using existing file as configuration file."
-        Copy-Item -Path $fileSource -Destination $fileDestination -Force
+        Move-Item -Path $fileSource -Destination $fileDestination -Force
     }
 }
 


### PR DESCRIPTION
If you create a custom config file in the Desktop with the name `config.xml` and execute the installer script, the `Get-ConfigFile` function (introduced in https://github.com/mandiant/flare-vm/pull/531) fails trying to copy the file to itself. Move the file instead of copying it to avoid the duplication and that it fails.

Closes https://github.com/mandiant/flare-vm/issues/537