### PR TITLE
config: Remove Auto arrange Desktop icons

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -131,7 +131,6 @@
         <registry-item name="Disable Windows Firewall (Standard Profile)" path="HKLM:\SOFTWARE\Policies\Microsoft\WindowsFirewall\StandardProfile" value="EnableFirewall" type="DWord" data="0" />
         <registry-item name="Add ZoomIt to Windows Start" path="HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\run" value="ZoomIt" type="String" data="C:\Tools\sysinternals\ZoomIt64.exe" />
         <registry-item name="Don't display ZoomIt GUI on login" path="HKCU:\Software\Sysinternals\ZoomIt" value="OptionsShown" type="DWord" data="1" />
-        <registry-item name="Auto arrange Desktop icons" path="HKCU:\SOFTWARE\Microsoft\Windows\Shell\Bags\1\Desktop" value="FFlags" type="DWord" data="1075839525"/>
         <registry-item name="Hide the .lnk extension" path="HKLM:\SOFTWARE\Classes\lnkfile" value="NeverShowExt" type="String" data=" "/>
         <!-- Set dark mode
         <registry-item name="Set Dark Mode on System" path="HKCU:\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize" value="SystemUsesLightTheme" type="DWord" data="0"/>


### PR DESCRIPTION
Modifying this registry key is not working as expected: the auto arrange option is not enabled.