### PR TITLE
[config] Add blobrunner to default config

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -10,6 +10,8 @@
         <package name="7zip-15-05.vm"/>
         <package name="apimonitor.vm"/>
         <package name="apktool.vm"/>
+        <package name="blobrunner.vm"/>
+        <package name="blobrunner64.vm"/>
         <package name="bytecodeviewer.vm"/>
         <package name="capa.vm"/>
         <package name="cmder.vm"/>


### PR DESCRIPTION
Add 32-bit and 64-bit versions of blobrunner to the default FLARE-VM configuration. These packages are added in the following PRs (which need to be merged before this one):
- https://github.com/mandiant/VM-Packages/pull/836
- https://github.com/mandiant/VM-Packages/pull/835

@mandiant/flare-vm any other package that should be added to the default config?
