### PR TITLE
[README] Fix broken download command

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ The VM should satisfy the following requirements:
 
 ### FLARE-VM installation
 * Open a `PowerShell` prompt as administrator
-* Download the installation script [`installer.ps1`](https://raw.githubusercontent.com/mandiant/flare-vm/main/install.ps1):
-  * `(New-Object net.webclient).DownloadFile('https://raw.githubusercontent.com/mandiant/flare-vm/main/install.ps1',"install.ps1")`
+* Download the installation script [`installer.ps1`](https://raw.githubusercontent.com/mandiant/flare-vm/main/install.ps1) to your Desktop:
+  * `(New-Object net.webclient).DownloadFile('https://raw.githubusercontent.com/mandiant/flare-vm/main/install.ps1',"$([Environment]::GetFolderPath("Desktop"))\install.ps1")`
 * Unblock the installation script:
   * `Unblock-File .\install.ps1`
 * Enable script execution:


### PR DESCRIPTION
The command to download the installation script seems to be broken and needs the whole path. This issue was introduced in https://github.com/mandiant/flare-vm/commit/be70f602f27b32c7e2922d31e93cf14d9e5e22c1. Thanks @jstrosch for reporting it!