### PR TITLE
[config] Remove imhex.vm

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -44,7 +44,6 @@
         <package name="idr.vm"/>
         <package name="ifpstools.vm"/>
         <package name="ilspy.vm"/>
-        <package name="imhex.vm"/>
         <package name="innoextract.vm"/>
         <package name="innounp.vm"/>
         <package name="isd.vm"/>


### PR DESCRIPTION
Remove ImHex from default configuration as it requires OpenGL 3.0 support. See https://github.com/mandiant/VM-Packages/issues/940 for more details.