### PR TITLE
[config] Update broken package

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -50,7 +50,7 @@
         <package name="libraries.python3.vm"/>
         <package name="malware-jail.vm"/>
         <package name="map.vm"/>
-        <package name="microsoft-windows-terminal.vm"/>
+        <package name="windows-terminal.vm"/>
         <package name="nasm.vm"/>
         <package name="net-reactor-slayer.vm"/>
         <package name="netcat.vm"/>


### PR DESCRIPTION
`microsoft-windows-terminal.vm` has been fixed and renamed to `windows-terminal.vm` in https://github.com/mandiant/VM-Packages/pull/936