### PR TITLE
Pin Windows Terminal as default console

### DIFF
--- a/CustomStartLayout.xml
+++ b/CustomStartLayout.xml
@@ -16,7 +16,7 @@
       <defaultlayout:TaskbarLayout>
         <taskbar:TaskbarPinList>
           <taskbar:DesktopApp DesktopApplicationLinkPath="%AppData%\Microsoft\Windows\Start Menu\Programs\System Tools\File Explorer.lnk"/>
-          <taskbar:DesktopApp DesktopApplicationLinkPath="%RAW_TOOLS_DIR%\Admin Command Prompt.lnk"/>
+          <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Productivity Tools\Windows Terminal.lnk"/>
           <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Utilities\CyberChef.lnk"/>
           <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Disassemblers\ida.lnk"/>
           <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Networking\FakeNet-NG.lnk"/>

--- a/config.xml
+++ b/config.xml
@@ -50,7 +50,6 @@
         <package name="libraries.python3.vm"/>
         <package name="malware-jail.vm"/>
         <package name="map.vm"/>
-        <package name="windows-terminal.vm"/>
         <package name="nasm.vm"/>
         <package name="net-reactor-slayer.vm"/>
         <package name="netcat.vm"/>
@@ -83,6 +82,7 @@
         <package name="vcbuildtools.vm"/>
         <package name="vcredist-all"/>
         <package name="windbg.vm"/>
+        <package name="windows-terminal.vm"/>
         <package name="wireshark.vm"/>
         <package name="x64dbg.ollydumpex.vm"/>
         <package name="x64dbg.scyllahide.vm"/>


### PR DESCRIPTION
This updates the custom layout for pinned items to use Windows Terminal instead of Command Prompt.

Closes https://github.com/mandiant/flare-vm/issues/563