### PR TITLE
Improve taskbar shortcut links

### DIFF
--- a/CustomStartLayout.xml
+++ b/CustomStartLayout.xml
@@ -20,10 +20,10 @@
           <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Utilities\CyberChef.lnk"/>
           <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Disassemblers\ida.lnk"/>
           <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Networking\FakeNet-NG.lnk"/>
-          <taskbar:DesktopApp DesktopApplicationLinkPath="%ProgramData%\chocolatey\bin\CFFExplorer.exe"/>
+          <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\PE\CFF Explorer.lnk"/>
           <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Utilities\procexp.lnk"/>
           <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Utilities\procmon.lnk"/>
-          <taskbar:DesktopApp DesktopApplicationLinkPath="%ProgramData%\chocolatey\bin\notepad++.exe"/>
+          <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Productivity Tools\notepad++.lnk"/>
           <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Utilities\VisualStudio.lnk"/>
         </taskbar:TaskbarPinList>
       </defaultlayout:TaskbarLayout>


### PR DESCRIPTION
This fixes https://github.com/mandiant/flare-vm/issues/582

Currently, `CFF Explorer` and `notepad++` will have a shortcut in the taskbar, but when clicked, it will show a second icon next to it for the running program, likely due to these using the chocolately shim shortcuts.

Now that we have an actual shortcut for `notepad++`, we can use that one directly, and also fix `CFF Explorer` to use the proper shortcut, and this mitigates this issue.