### PR TITLE
[README] Add password expiration

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -229,10 +229,8 @@ if (-not $noChecks.IsPresent) {
 
     # Check for spaces in the username, exit if identified
     Write-Host "[+] Checking for spaces in the username..."
-    $currentUsername = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
-    $extractedUsername = $currentUsername -replace '^.*\\'
-    if ($extractedUsername -match '\s') {
-        Write-Host "`t[!] Username '$extractedUsername' contains a space and will break installation." -ForegroundColor Red
+    if (${Env:userName} -match '\s') {
+        Write-Host "`t[!] Username '${Env:UserName}' contains a space and will break installation." -ForegroundColor Red
         Write-Host "`t[!] Exiting..." -ForegroundColor Red
         Start-Sleep 3
         exit 1

--- a/install.ps1
+++ b/install.ps1
@@ -314,6 +314,9 @@ if (-not $noChecks.IsPresent) {
         }
     }
 
+    Write-Host "[+] Setting password to never expire to avoid that a password expiration blocks the installation..."
+    Set-LocalUser -Name  "${Env:UserName}" -PasswordNeverExpires $true
+
     # Prompt user to remind them to take a snapshot
     Write-Host "[-] Have you taken a VM snapshot to ensure you can revert to pre-installation state? (Y/N): " -ForegroundColor Yellow -NoNewline
     $response = Read-Host


### PR DESCRIPTION
A password expiration blocks the FLARE-VM installation as it asks to change the password after a restart. I had this issue today. Document how to set `Password never expires` in the user properties in `lusrmgr.msc` to avoid the issue.