### PR TITLE
[CustomStartLayout.xml] Fix VisualStudio

### DIFF
--- a/CustomStartLayout.xml
+++ b/CustomStartLayout.xml
@@ -24,7 +24,7 @@
           <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Utilities\procexp.lnk"/>
           <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Utilities\procmon.lnk"/>
           <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Productivity Tools\notepad++.lnk"/>
-          <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Utilities\VisualStudio.lnk"/>
+          <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Productivity Tools\VisualStudio.lnk"/>
         </taskbar:TaskbarPinList>
       </defaultlayout:TaskbarLayout>
     </CustomTaskbarLayoutCollection>


### PR DESCRIPTION
We have changed visualstudio.vm of category breaking the shortcut in the taskbar.