### PR TITLE
Add regcool to default tools

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -80,6 +80,7 @@
         <package name="procdot.vm"/>
         <package name="processdump.vm"/>
         <package name="reg_export.vm"/>
+        <package name="regcool.vm"/>
         <package name="regshot.vm"/>
         <package name="resourcehacker.vm"/>
         <package name="rundotnetdll.vm"/>


### PR DESCRIPTION
This tool gives us a nicer Registry Viewer with a lot more features than the standard `regedit`, and it also incorporates a feature similar to `regshot` as well, which is pretty sweet.