### PR TITLE
Added improvements to reduce errors and such

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -76,7 +76,16 @@ param (
   [switch]$noReboots,
   [switch]$noChecks
 )
-$ErrorActionPreference = "Stop"
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+ 
+# https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.localaccounts/set-localuser
+if ( -not ([Environment]::Is64BitProcess)) {
+    Write-Host "`t[!] It seems like you are using 32 bit powershell. Exiting because some commands do not work correctly in this mode." -ForegroundColor Red
+    Write-Host "`t[-] Hint: Don't run powershell x86" -ForegroundColor Yellow
+    Start-Sleep 3
+    exit 1
+}
 
 # Function to test the network stack. Ping/GET requests to the resource to ensure that network stack looks good for installation
 function Test-WebConnection {
@@ -94,7 +103,7 @@ function Test-WebConnection {
 
     $response = $null
     try {
-        $response = Invoke-WebRequest -Uri "https://$url" -UseBasicParsing
+        $response = Invoke-WebRequest -Uri "https://$url" -UseBasicParsing -DisableKeepAlive
     }
     catch {
         Write-Host "`t[!] Error accessing $url. Exception: $($_.Exception.Message)`n`t[!] Check your network settings." -ForegroundColor Red
@@ -257,9 +266,9 @@ if (-not $noChecks.IsPresent) {
     }
 
     # Internet connectivity checks
-    Test-WebConnection "google.com"
-    Test-WebConnection "github.com"
-    Test-WebConnection "raw.githubusercontent.com"
+    Test-WebConnection 'microsoft.com'
+    Test-WebConnection 'github.com'
+    Test-WebConnection 'raw.githubusercontent.com'
 
     Write-Host "`t[+] Network connectivity looks good" -ForegroundColor Green
 

--- a/install.ps1
+++ b/install.ps1
@@ -266,9 +266,9 @@ if (-not $noChecks.IsPresent) {
     }
 
     # Internet connectivity checks
-    Test-WebConnection 'microsoft.com'
-    Test-WebConnection 'github.com'
     Test-WebConnection 'google.com'
+    Test-WebConnection 'github.com'
+    Test-WebConnection 'raw.githubusercontent.com'
 
     Write-Host "`t[+] Network connectivity looks good" -ForegroundColor Green
 

--- a/install.ps1
+++ b/install.ps1
@@ -268,7 +268,7 @@ if (-not $noChecks.IsPresent) {
     # Internet connectivity checks
     Test-WebConnection 'microsoft.com'
     Test-WebConnection 'github.com'
-    Test-WebConnection 'raw.githubusercontent.com'
+    Test-WebConnection 'google.com'
 
     Write-Host "`t[+] Network connectivity looks good" -ForegroundColor Green
 


### PR DESCRIPTION
I added 4 different changes to this script.
1. On powershell 5.1 (comes with default installation of windows), there is a significant time-burner for Invoke-Webrequest  and other commands. It comes from writing that light blue progress bar at the top of the window. More info here: https://github.com/PowerShell/PowerShell/issues/2138 
2. My next improvement is handling if a user accidently clicks on PowerShell x86. The script then corrects this human error.
3. Disable Keep alive for invoke web request is just because we should not assume that user will have further interaction beyond what is required on the script, so we should remove for potential less latency.
4. I added Microsoft.com instead of Google because of how likely of each to be blocked. This is also for personal privacy reasons, this features adds nothing extra but on a windows machine is usually preferred. I chose not to do a more privacy respecting website because that might also be blocked in a weird corporate environment. 