### PR TITLE
[config] Add microsoft-office.vm

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -62,6 +62,7 @@
         <package name="magika.vm"/>
         <package name="malware-jail.vm"/>
         <package name="map.vm"/>
+        <package name="microsoft-office.vm"/>
         <package name="nasm.vm"/>
         <package name="net-reactor-slayer.vm"/>
         <package name="netcat.vm"/>


### PR DESCRIPTION
Add Microsoft Office (using the package create in https://github.com/mandiant/VM-Packages/pull/1120) to the default FLARE-VM configuration as it is useful to analysis Office related malware such as excel macros.