### PR TITLE
[config] Add internet_detector.vm

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -56,6 +56,7 @@
         <package name="ilspy.vm"/>
         <package name="innoextract.vm"/>
         <package name="innounp.vm"/>
+        <package name="internet_detector.vm"/>
         <package name="isd.vm"/>
         <package name="js-deobfuscator.vm"/>
         <package name="libraries.python3.vm"/>


### PR DESCRIPTION
Add `internet_detector.vm` introduced in https://github.com/mandiant/VM-Packages/pull/1121 to the default configuration. Note that the tool is not running by default at the moment because of the noise in fakenet: https://github.com/mandiant/flare-fakenet-ng/issues/190 but we are considering [running the tool by default with a scheduled task](https://github.com/mandiant/VM-Packages/blob/24c8bcadf3a89d99401936ca6c49ffbfd6f199df/packages/internet_detector.vm/tools/chocolateyinstall.ps1#L28).

![image](https://github.com/user-attachments/assets/488596f8-bf52-4f14-9b79-170ad196aee9)
