### PR TITLE
[vbox-export-snapshots] Fix VM name & small improvements

### DIFF
--- a/virtualbox/vbox-export-snapshots.py
+++ b/virtualbox/vbox-export-snapshots.py
@@ -10,6 +10,7 @@ import hashlib
 import virtualbox
 from virtualbox.library import VirtualSystemDescriptionType as DescType
 from virtualbox.library import NetworkAttachmentType as NetType
+from virtualbox.library import ExportOptions as ExportOps
 from datetime import datetime
 
 # Base name of the exported VMs
@@ -73,7 +74,7 @@ if __name__ == "__main__":
             sys_description = vm.export_to(appliance, exported_vm_name)
             sys_description.set_final_value(DescType.name, exported_vm_name)
             sys_description.set_final_value(DescType.description, description)
-            progress = appliance.write("ovf-1.0", [], filename)
+            progress = appliance.write("ovf-1.0", [ExportOps.create_manifest], filename)
             print(f"Exporting {filename} (this will take some time, go for an 🍦!)")
             progress.wait_for_completion(-1)
 

--- a/virtualbox/vbox-export-snapshots.py
+++ b/virtualbox/vbox-export-snapshots.py
@@ -71,6 +71,7 @@ if __name__ == "__main__":
             filename = os.path.join(export_directory, f"{exported_vm_name}.ova")
             appliance = vbox.create_appliance()
             sys_description = vm.export_to(appliance, exported_vm_name)
+            sys_description.set_final_value(DescType.name, exported_vm_name)
             sys_description.set_final_value(DescType.description, description)
             progress = appliance.write("ovf-1.0", [], filename)
             print(f"Exporting {filename} (this will take some time, go for an 🍦!)")


### PR DESCRIPTION
We are using `exported_vm_name` to name the exported `.ova` file but keeping the original VM name (`FLARE-VM.testing`) for the appliance name (the VM name when importing it). Change the VM appliance name to match the `.ova` file name.

Use the `create_manifest` export option that writes the optional manifest file (`.mf`) which is used for integrity checks prior import as done by default in the export manual process.

In addition, refactor session creation code.