### PR TITLE
First step to fix Windows 11 install failure

### DIFF
--- a/LayoutModification.xml
+++ b/LayoutModification.xml
@@ -21,8 +21,8 @@
           <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Disassemblers\ida.lnk"/>
           <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Networking\fakenet.lnk"/>
           <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\PE\CFF Explorer.lnk"/>
-          <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Utilities\procexp.lnk"/>
-          <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Utilities\procmon.lnk"/>
+          <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Utilities\procexp64.lnk"/>
+          <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Utilities\procmon64.lnk"/>
           <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Productivity Tools\notepad++.lnk"/>
           <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Productivity Tools\VisualStudio.lnk"/>
         </taskbar:TaskbarPinList>


### PR DESCRIPTION
This is a 2 fold PR.

1. First step for addressing the installation failure in Windows 11 as noted here: https://github.com/mandiant/flare-vm/issues/603. This changes the name of our custom start layout to the name that Windows uses when actually implementing the custom layout, which will then be used in (2nd PR here) to store it in the correct location.
2. This also fixes Procmon and Process Explorer duplication in the taskbar as noted in https://github.com/mandiant/VM-Packages/issues/1100

**NOTE**: This WILL break the install until the 2nd PR is merged due to the name change for the custom layout.