### PR TITLE
Fix Custom Taskbar from breaking on Win 11

### DIFF
--- a/LayoutModification.xml
+++ b/LayoutModification.xml
@@ -21,8 +21,8 @@
           <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Disassemblers\ida.lnk"/>
           <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Networking\fakenet.lnk"/>
           <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\PE\CFF Explorer.lnk"/>
-          <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Utilities\procexp.lnk"/>
-          <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Utilities\procmon.lnk"/>
+          <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Utilities\procexp64.lnk"/>
+          <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Utilities\procmon64.lnk"/>
           <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Productivity Tools\notepad++.lnk"/>
           <taskbar:DesktopApp DesktopApplicationLinkPath="%TOOL_LIST_DIR%\Productivity Tools\VisualStudio.lnk"/>
         </taskbar:TaskbarPinList>

--- a/install.ps1
+++ b/install.ps1
@@ -120,7 +120,7 @@ function Test-WebConnection {
     Write-Host "`t[+] Internet connectivity check for $url passed" -ForegroundColor Green
 }
 
-# Function used for getting configuration files (such as config.xml and CustomStartLayout.xml)
+# Function used for getting configuration files (such as config.xml and LayoutModification.xml)
 function Get-ConfigFile {
     param (
         [string]$fileDestination,
@@ -910,9 +910,9 @@ $configXml.save((Join-Path ${Env:VM_COMMON_DIR} "packages.xml"))
 
 # Custom Start Layout setup
 Write-Host "[+] Checking for custom Start Layout file..."
-$layoutPath = Join-Path ${Env:VM_COMMON_DIR} "CustomStartLayout.xml"
+$layoutPath = Join-Path "C:\Users\Default\AppData\Local\Microsoft\Windows\Shell" "LayoutModification.xml"
 if ([string]::IsNullOrEmpty($customLayout)) {
-    $layoutSource = 'https://raw.githubusercontent.com/mandiant/flare-vm/main/CustomStartLayout.xml'
+    $layoutSource = 'https://raw.githubusercontent.com/mandiant/flare-vm/main/LayoutModification.xml'
 } else {
     $layoutSource = $customLayout
 }


### PR DESCRIPTION
This is a 2 fold PR.

1. This is the first step for addressing the installation failure in Windows 11 as noted here: https://github.com/mandiant/flare-vm/issues/603. This changes the name of our custom start layout to the name that Windows uses when actually implementing the custom layout, which will then be used in (2nd PR [here](https://github.com/mandiant/VM-Packages/pull/1137), from VM-Packages) to store it in the correct location.

2. This also fixes Procmon and Process Explorer duplication in the taskbar as noted in https://github.com/mandiant/VM-Packages/issues/1100

**NOTE:** This WILL break the install until the 2nd PR is merged due to the name change for the custom layout.