### PR TITLE
Port virtualbox scripts to VBoxManage CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 *.class
 *.o
 *.so
+__pycache__/
 
 # Packages #
 ############
@@ -35,3 +36,7 @@ Thumbs.db
 # Pycharm artifacts
 ###################
 .idea
+
+# vscode
+# #################
+.vscode/

--- a/virtualbox/README.md
+++ b/virtualbox/README.md
@@ -73,7 +73,7 @@ Cleaning FLARE-VM.20240604 🫧 Snapshots to delete:
 VM state: Paused
 ⚠️  Snapshot deleting is slower in a running VM and may fail in a changing state
 
-Confirm deletion ('y'):y
+Confirm deletion (press 'y'):y
 
 Deleting... (this may take some time, go for an 🍦!)
   🫧 DELETED 'Snapshot 1'

--- a/virtualbox/vbox-adapter-check.py
+++ b/virtualbox/vbox-adapter-check.py
@@ -1,57 +1,120 @@
 #!/usr/bin/python3
 
+import argparse
+import re
 import sys
 import textwrap
-import argparse
-import virtualbox
-from virtualbox.library import NetworkAttachmentType as NetType
+
+import gi
+
+gi.require_version("Notify", "0.7")
 from gi.repository import Notify
 
-DYNAMIC_VM_NAME = '.dynamic'
-DISABLED_ADAPTER_TYPE = NetType.host_only
-ALLOWED_ADAPTER_TYPES = (NetType.host_only, NetType.internal, NetType.null)
+from vboxcommon import *
 
-ENABLED_STRS = ('Disabled','Enabled ')
+DYNAMIC_VM_NAME = ".dynamic"
+DISABLED_ADAPTER_TYPE = "hostonly"
+ALLOWED_ADAPTER_TYPES = ("hostonly", "intnet", "none")
 
-def check_and_disable_internet_access(session, machine_name, max_adapters, skip_disabled, do_not_modify):
-    """
-    Checks if a VM's network adapter is set to an internet-accessible mode
-    and disables it if necessary, showing a warning popup.
 
-    Args:
-        session: The session of the virtual machine to check.
-    """
-    adapters_with_internet = []
-    for i in range(max_adapters):
-        adapter = session.machine.get_network_adapter(i)
+def get_vm_uuids(dynamic_only):
+    """Gets the machine UUID(s) for a given VM name using 'VBoxManage list vms'."""
+    machine_guids = []
+    try:
+        # regex VM name and extract the GUID
+        # "FLARE-VM.testing" {b76d628b-737f-40a3-9a16-c5f66ad2cfcc}
+        vms_output = run_vboxmanage(["list", "vms"])
+        pattern = r'"(.*?)" \{(.*?)\}'
+        matches = re.findall(pattern, vms_output)
+        for match in matches:
+            vm_name = match[0]
+            machine_guid = match[1]
+            # either get all vms if dynamic_only false, or just the dynamic vms if true
+            if (not dynamic_only) or DYNAMIC_VM_NAME in vm_name:
+                machine_guids.append((vm_name, machine_guid))
+    except Exception as e:
+        raise Exception(f"Error finding machines UUIDs") from e
+    return machine_guids
 
-        if skip_disabled and not adapter.enabled:
-            continue
 
-        print(f"{machine_name} {i+1}: {ENABLED_STRS[adapter.enabled]} {adapter.attachment_type}")
+def change_network_adapters_to_hostonly(
+    machine_guid, vm_name, hostonly_ifname, do_not_modify
+):
+    """Verify all adapters are in an allowed configuration. Must be poweredoff"""
+    try:
+        # gather adapters in incorrect configurations
+        nics_with_internet = []
+        invalid_nics_msg = ""
 
-        if DYNAMIC_VM_NAME in machine_name and adapter.attachment_type not in ALLOWED_ADAPTER_TYPES:
-            adapters_with_internet.append(i)
-            if not do_not_modify:
-                # Disable the adapter
-                adapter.attachment_type = DISABLED_ADAPTER_TYPE
+        # nic1="hostonly"
+        # nictype1="82540EM"
+        # nicspeed1="0"
+        # nic2="none"
+        # nic3="none"
+        # nic4="none"
+        # nic5="none"
+        # nic6="none"
+        # nic7="none"
+        # nic8="none"
 
-    if adapters_with_internet:
-        adapters_str = ", ".join(str(i+1) for i in adapters_with_internet)
-        if do_not_modify:
-            message = f"{machine_name} may be connected to the internet on adapter(s): {adapters_str}. Please double check your VMs settings."
+        vminfo = run_vboxmanage(["showvminfo", machine_guid, "--machinereadable"])
+        for nic_number, nic_value in re.findall(
+            '^nic(\d+)="(\S+)"', vminfo, flags=re.M
+        ):
+            if nic_value not in ALLOWED_ADAPTER_TYPES:
+                nics_with_internet.append(f"nic{nic_number}")
+                invalid_nics_msg += f"{nic_number} "
+
+        # modify the invalid adapters if allowed
+        if nics_with_internet:
+            for nic in nics_with_internet:
+                if do_not_modify:
+                    message = f"{vm_name} may be connected to the internet on adapter(s): {nic}. Please double check your VMs settings."
+                else:
+                    message = f"{vm_name} may be connected to the internet on adapter(s): {nic}. The network adapter(s) have been disabled automatically to prevent an undesired internet connectivity. Please double check your VMs settings."
+                    # different commands are necessary if the machine is running.
+                    if get_vm_state(machine_guid) == "poweroff":
+                        run_vboxmanage(
+                            [
+                                "modifyvm",
+                                machine_guid,
+                                f"--{nic}",
+                                DISABLED_ADAPTER_TYPE,
+                            ]
+                        )
+                    else:
+                        run_vboxmanage(
+                            [
+                                "controlvm",
+                                machine_guid,
+                                nic,
+                                "hostonly",
+                                hostonly_ifname,
+                            ]
+                        )
+                    print(f"Set VM {vm_name} adaper {nic} to hostonly")
+
+            if do_not_modify:
+                message = f"{vm_name} may be connected to the internet on adapter(s): {invalid_nics_msg}. Please double check your VMs settings."
+            else:
+                message = f"{vm_name} may be connected to the internet on adapter(s): {invalid_nics_msg}. The network adapter(s) have been disabled automatically to prevent an undesired internet connectivity. Please double check your VMs settings."
+
+            # Show notification using PyGObject
+            Notify.init("VirtualBox adapter check")
+            notification = Notify.Notification.new(
+                f"INTERNET IN VM: {vm_name}", message, "dialog-error"
+            )
+            # Set highest priority
+            notification.set_urgency(2)
+            notification.show()
+            print(f"{vm_name} network configuration not ok, sent notifaction")
+            return
         else:
-            message = f"{machine_name} may be connected to the internet on adapter(s): {adapters_str}. The network adapter(s) have been disabled automatically to prevent an undesired internet connectivity. Please double check your VMs settings."
+            print(f"{vm_name} network configuration is ok")
+            return
 
-        # Show notification using PyGObject
-        Notify.init("VirtualBox adapter check")
-        notification = Notify.Notification.new(f"INTERNET IN VM: {machine_name}", message, "dialog-error")
-        # Set highest priority
-        notification.set_urgency(2)
-        notification.show()
-
-    session.machine.save_settings()
-    session.unlock_machine()
+    except Exception as e:
+        raise Exception("Failed to verify VM adapter configuration") from e
 
 
 def main(argv=None):
@@ -66,12 +129,6 @@ def main(argv=None):
 
           # Print status of all internet adapters without modifying any of them
           vbox-adapter-check.vm --do_not_modify
-
-          # Print status of enabled internet adapters and disabled the enabled adapters with internet access in VMs with {DYNAMIC_VM_NAME} in the name
-          vbox-adapter-check.vm --skip_disabled
-
-          # # Print status of enabled internet adapters without modifying any of them
-          vbox-adapter-check.vm --skip_disabled --do_not_modify
         """
     )
     parser = argparse.ArgumentParser(
@@ -79,15 +136,30 @@ def main(argv=None):
         epilog=epilog,
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    parser.add_argument("--do_not_modify", action="store_true", help="Only print the status of the internet adapters without modifying them.")
-    parser.add_argument("--skip_disabled", action="store_true", help="Skip the disabled adapters.")
+    parser.add_argument(
+        "--do_not_modify",
+        action="store_true",
+        help="Only print the status of the internet adapters without modifying them.",
+    )
+    parser.add_argument(
+        "--dynamic_only",
+        action="store_true",
+        help="Only scan VMs with .dynamic in the name",
+    )
     args = parser.parse_args(args=argv)
 
-    vbox = virtualbox.VirtualBox()
-    for machine in vbox.machines:
-        session = machine.create_session()
-        max_adapters = vbox.system_properties.get_max_network_adapters(machine.chipset_type)
-        check_and_disable_internet_access(session, machine.name, max_adapters, args.skip_disabled, args.do_not_modify)
+    try:
+        hostonly_ifname = ensure_hostonlyif_exists()
+        machine_guids = get_vm_uuids(args.dynamic_only)
+        if len(machine_guids) > 0:
+            for vm_name, machine_guid in machine_guids:
+                change_network_adapters_to_hostonly(
+                    machine_guid, vm_name, hostonly_ifname, args.do_not_modify
+                )
+        else:
+            print(f"[Warning ⚠️] No VMs found")
+    except Exception as e:
+        print(f"Error verifying dynamic VM hostonly configuration: {e}")
 
 
 if __name__ == "__main__":

--- a/virtualbox/vboxcommon.py
+++ b/virtualbox/vboxcommon.py
@@ -1,0 +1,138 @@
+import subprocess
+import time
+
+
+# cmd is an array of string arguments to pass
+def run_vboxmanage(cmd):
+    """Runs a VBoxManage command and returns the output."""
+    try:
+        result = subprocess.run(
+            ["VBoxManage"] + cmd, capture_output=True, text=True, check=True
+        )
+        return result.stdout
+    except subprocess.CalledProcessError as e:
+        raise RuntimeError(f"Error running VBoxManage command: {e} ({e.stderr})")
+
+
+def ensure_hostonlyif_exists():
+    """Gets the name of, or creates a new hostonlyif"""
+    try:
+        # Name:            vboxnet0
+        # GUID:            f0000000-dae8-4abf-8000-0a0027000000
+        # DHCP:            Disabled
+        # IPAddress:       192.168.56.1
+        # NetworkMask:     255.255.255.0
+        # IPV6Address:     fe80::800:27ff:fe00:0
+        # IPV6NetworkMaskPrefixLength: 64
+        # HardwareAddress: 0a:00:27:00:00:00
+        # MediumType:      Ethernet
+        # Wireless:        No
+        # Status:          Up
+        # VBoxNetworkName: HostInterfaceNetworking-vboxnet0
+
+        # Find existing hostonlyif
+        hostonlyifs_output = run_vboxmanage(["list", "hostonlyifs"])
+        for line in hostonlyifs_output.splitlines():
+            if line.startswith("Name:"):
+                hostonlyif_name = line.split(":")[1].strip()
+                print(f"Found existing hostonlyif {hostonlyif_name}")
+                return hostonlyif_name
+
+        # No host-only interface found, create one
+        print("No host-only interface found. Creating one...")
+        run_vboxmanage(["hostonlyif", "create"])
+        hostonlyifs_output = run_vboxmanage(
+            ["list", "hostonlyifs"]
+        )  # Get the updated list
+        for line in hostonlyifs_output.splitlines():
+            if line.startswith("Name:"):
+                hostonlyif_name = line.split(":")[1].strip()
+                print(f"Created hostonlyif {hostonlyif_name}")
+                return hostonlyif_name
+        print("Failed to create new hostonlyif. Exiting...")
+        raise Exception("Failed to create new hostonlyif.")
+    except Exception as e:
+        raise Exception("Failed to verify host-only interface exists") from e
+
+
+def get_vm_state(machine_guid):
+    """Gets the VM state using 'VBoxManage showvminfo'."""
+    # VMState="poweroff"
+    # VMStateChangeTime="2025-01-02T16:31:51.000000000"
+
+    vminfo = run_vboxmanage(["showvminfo", machine_guid, "--machinereadable"])
+    for line in vminfo.splitlines():
+        if line.startswith("VMState"):
+            return line.split("=")[1].strip('"')
+    raise Exception(f"Could not start VM '{machine_guid}'")
+
+
+def ensure_vm_running(machine_guid):
+    """Checks if the VM is running and starts it if it's not.
+    Waits up to 1 minute for the VM to transition to the 'running' state.
+    """
+    try:
+        vm_state = get_vm_state(machine_guid)
+        if vm_state != "running":
+            print(
+                f"VM {machine_guid} is not running (state: {vm_state}). Starting VM..."
+            )
+            run_vboxmanage(["startvm", machine_guid, "--type", "gui"])
+
+            # Wait for VM to start (up to 1 minute)
+            timeout = 60  # seconds
+            check_interval = 5  # seconds
+            start_time = time.time()
+            while time.time() - start_time < timeout:
+                vm_state = get_vm_state(machine_guid)
+                if vm_state == "running":
+                    print(f"VM {machine_guid} started.")
+                    time.sleep(5)  # wait a bit to be careful and avoid any weird races
+                    return
+                print(f"Waiting for VM (state: {vm_state})")
+                time.sleep(check_interval)
+            print("Timeout waiting for VM to start. Exiting...")
+            raise TimeoutError(
+                f"VM did not start within the timeout period {timeout}s."
+            )
+        else:
+            print("VM is already running.")
+            return
+    except Exception as e:
+        raise Exception(f"Could not ensure '{machine_guid}' running") from e
+
+
+def ensure_vm_shutdown(machine_guid):
+    """Checks if the VM is running and shuts it down if it is."""
+    try:
+        vm_state = get_vm_state(machine_guid)
+        if vm_state == "saved":
+            print(
+                f"VM {machine_guid} is in a saved state. Powering on for a while then shutting down..."
+            )
+            ensure_vm_running(machine_guid)
+            time.sleep(120)  # 2 minutes to boot up
+
+        vm_state = get_vm_state(machine_guid)
+        if vm_state != "poweroff":
+            print(f"VM {machine_guid} is not powered off. Shutting down VM...")
+            run_vboxmanage(["controlvm", machine_guid, "poweroff"])
+
+            # Wait for VM to shut down (up to 1 minute)
+            timeout = 60  # seconds
+            check_interval = 5  # seconds
+            start_time = time.time()
+            while time.time() - start_time < timeout:
+                vm_state = get_vm_state(machine_guid)
+                if vm_state == "poweroff":
+                    print(f"VM {machine_guid} is shut down (status: {vm_state}).")
+                    time.sleep(5)  # wait a bit to be careful and avoid any weird races
+                    return
+                time.sleep(check_interval)
+            print("Timeout waiting for VM to shut down. Exiting...")
+            raise TimeoutError("VM did not shut down within the timeout period.")
+        else:
+            print(f"VM {machine_guid} is already shut down (state: {vm_state}).")
+            return
+    except Exception as e:
+        raise Exception(f"Could not ensure '{machine_guid}' shutdown") from e


### PR DESCRIPTION
Ports to VBoxManage CLI, identical logic otherwise. Errors handled gracefully for the most part. Output:
```
stepheneckels@flarevm-build-2:~/source/repos/flare-vm$ python3 virtualbox/vbox-export-snapshots.py 
Starting operations on FLARE-VM
VM {b76d628b-737f-40a3-9a16-c5f66ad2cfcc} is already shut down (state: poweroff).
Restored 'FLARE-VM'
Found existing hostonlyif vboxnet0
Verified hostonly nic configuration correct
Power cycling before export...
VM {b76d628b-737f-40a3-9a16-c5f66ad2cfcc} is not running (state: poweroff). Starting VM...
VM {b76d628b-737f-40a3-9a16-c5f66ad2cfcc} started.
VM {b76d628b-737f-40a3-9a16-c5f66ad2cfcc} is not powered off. Shutting down VM...
VM {b76d628b-737f-40a3-9a16-c5f66ad2cfcc} is shut down (status: poweroff).
Power cycling done.
Exporting /usr/local/google/home/stepheneckels/EXPORTED VMS/FLARE-VM.20241009.dynamic.ova (this will take some time, go for an 🍦!)
Exported /usr/local/google/home/stepheneckels/EXPORTED VMS/FLARE-VM.20241009.dynamic.ova! 🎉
All operations on FLARE-VM successful ✅
Starting operations on FLARE-VM.full
VM {b76d628b-737f-40a3-9a16-c5f66ad2cfcc} is already shut down (state: poweroff).
Restored 'FLARE-VM.full'
Found existing hostonlyif vboxnet0
Changed nic1 to hostonly
Verified hostonly nic configuration correct
Power cycling before export...
VM {b76d628b-737f-40a3-9a16-c5f66ad2cfcc} is not running (state: poweroff). Starting VM...
VM {b76d628b-737f-40a3-9a16-c5f66ad2cfcc} started.
VM {b76d628b-737f-40a3-9a16-c5f66ad2cfcc} is not powered off. Shutting down VM...
VM {b76d628b-737f-40a3-9a16-c5f66ad2cfcc} is shut down (status: poweroff).
Power cycling done.
Exporting /usr/local/google/home/stepheneckels/EXPORTED VMS/FLARE-VM.20241009.full.dynamic.ova (this will take some time, go for an 🍦!)
Exported /usr/local/google/home/stepheneckels/EXPORTED VMS/FLARE-VM.20241009.full.dynamic.ova! 🎉
All operations on FLARE-VM.full successful ✅
Starting operations on FLARE-VM.EDU
VM {b76d628b-737f-40a3-9a16-c5f66ad2cfcc} is already shut down (state: poweroff).
Restored 'FLARE-VM.EDU'
Found existing hostonlyif vboxnet0
Changed nic1 to hostonly
Verified hostonly nic configuration correct
Power cycling before export...
VM {b76d628b-737f-40a3-9a16-c5f66ad2cfcc} is not running (state: poweroff). Starting VM...
VM {b76d628b-737f-40a3-9a16-c5f66ad2cfcc} started.
VM {b76d628b-737f-40a3-9a16-c5f66ad2cfcc} is not powered off. Shutting down VM...
VM {b76d628b-737f-40a3-9a16-c5f66ad2cfcc} is shut down (status: poweroff).
Power cycling done.
Exporting /usr/local/google/home/stepheneckels/EXPORTED VMS/FLARE-VM.20241009.EDU.ova (this will take some time, go for an 🍦!)
Exported /usr/local/google/home/stepheneckels/EXPORTED VMS/FLARE-VM.20241009.EDU.ova! 🎉
All operations on FLARE-VM.EDU successful ✅
Done. Exiting...
```