### PR TITLE
[config] Add chrome.extensions.vm

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -16,6 +16,7 @@
         <package name="blobrunner64.vm"/>
         <package name="bytecodeviewer.vm"/>
         <package name="capa.vm"/>
+        <package name="chrome.extensions.vm"/>
         <package name="cmder.vm"/>
         <package name="codetrack.vm"/>
         <package name="cryptotester.vm"/>


### PR DESCRIPTION
Add the `chrome.extensions.vm` package (created in https://github.com/mandiant/VM-Packages/pull/1139/files) to the default configuration. This package installs several chrome extensions that are for example useful to analyse credentials stealers.