### PR TITLE
Force DNS requests to always come from requesting process

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -171,6 +171,7 @@
         <registry-item name="Add ZoomIt to Windows Start" path="HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\run" value="ZoomIt" type="String" data="C:\Tools\sysinternals\ZoomIt64.exe" />
         <registry-item name="Don't display ZoomIt GUI on login" path="HKCU:\Software\Sysinternals\ZoomIt" value="OptionsShown" type="DWord" data="1" />
         <registry-item name="Hide the .lnk extension" path="HKLM:\SOFTWARE\Classes\lnkfile" value="NeverShowExt" type="String" data=" "/>
+        <registry-item name="Force DNS requests to always come from requesting process" path="HKLM:\SYSTEM\CurrentControlSet\services\Dnscache" value="Start" type="DWord" data="4" />
         <!-- Set dark mode
         <registry-item name="Set Dark Mode on System" path="HKCU:\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize" value="SystemUsesLightTheme" type="DWord" data="0"/>
         <registry-item name="Set Dark Mode on Apps" path="HKCU:\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize" value="AppsUseLightTheme" type="DWord" data="0"/>


### PR DESCRIPTION
This works in tandem with https://github.com/mandiant/VM-Packages/pull/1178 so that internet_detector will be blocked properly within FakeNet using Process Block List.