### PR TITLE
[config] Remove netcat

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -70,7 +70,6 @@
         <package name="microsoft-office.vm"/>
         <package name="nasm.vm"/>
         <package name="net-reactor-slayer.vm"/>
-        <package name="netcat.vm"/>
         <package name="notepadplusplus.vm"/>
         <package name="notepadpp.plugin.compare.vm"/>
         <package name="notepadpp.plugin.jstool.vm"/>


### PR DESCRIPTION
Remove netcat as the community package has been unlisted. nmap.vm already installs ncat which provides similar functionality.