### PR TITLE
[config] Add ipython

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -59,6 +59,7 @@
         <package name="innoextract.vm"/>
         <package name="innounp.vm"/>
         <package name="internet_detector.vm"/>
+        <package name="ipython.vm"/>
         <package name="isd.vm"/>
         <package name="js-beautify.vm"/>
         <package name="js-deobfuscator.vm"/>


### PR DESCRIPTION
I think we forgot to add ipython.vm (created in https://github.com/mandiant/VM-Packages/pull/1143) to the default config. Or is there a reason not to add it? :thinking: 