### PR TITLE
Fix for Issue #640 - config.xml misformatted

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <!--
  Copyright 2017 Google LLC
 
@@ -14,7 +15,6 @@
  limitations under the License.
 -->
 
-﻿<?xml version="1.0" encoding="utf-8"?>
 <config>
     <envs>
         <env name="VM_COMMON_DIR" value="%ProgramData%\_VM"/>


### PR DESCRIPTION
- Move the license after the opening XML tag. Per spec, first characters of an XML file must be `<?xml`
> ... encoding must begin with an XML encoding declaration, in which the first characters must be '<?xml' ...
- Remove the BOM as it is not needed for UTF-8 encoded XML files

Fixes #640

CLA has been signed.