### PR TITLE
[vbox-clean-snapshots.py] Fix several bugs & improve code

### DIFF
--- a/virtualbox/vbox-clean-snapshots.py
+++ b/virtualbox/vbox-clean-snapshots.py
@@ -58,9 +58,7 @@ def get_snapshot_children(vm_name, root_snapshot_name, protected_snapshots):
         # find the root SnapshotName by matching the name
         root_snapshotid = None
         for snapshotid, snapshot_name in snapshots:
-            if snapshot_name.lower() == root_snapshot_name.lower() and (
-                not any(p.lower() in snapshot_name.lower() for p in protected_snapshots)
-            ):
+            if snapshot_name.lower() == root_snapshot_name.lower():
                 root_snapshotid = snapshotid
 
         if not root_snapshotid:

--- a/virtualbox/vbox-clean-snapshots.py
+++ b/virtualbox/vbox-clean-snapshots.py
@@ -34,23 +34,27 @@ def get_snapshot_children(vm_name, root_snapshot_name, protected_snapshots):
       A list of snapshot names that are children of the given snapshot. The list is ordered by dependent relationships.
     """
     try:
-        # SnapshotName="Fresh"
-        # SnapshotUUID="8da3571a-1c66-4c3e-8a22-a87973253ae8"
-        # SnapshotName-1="FLARE-VM"
-        # SnapshotUUID-1="23d7b5f3-2e9a-41ef-a908-89b9ac873033"
-        # SnapshotName-1-1="Child2Snapshot"
-        # SnapshotUUID-1-1="adf91b7d-403f-478b-9bb4-89c477081dd6"
-        # SnapshotName-2="Child1SnapshotTesting"
-        # SnapshotUUID-2="db50b1e9-f51c-4308-b577-da5a41e01068"
-        # Fresh
-        #   ├─ FLARE-VM
-        #   │   └─ Child2Snapshot
-        #   └─ Child1SnapshotTesting
-        # Current State
+        # Example of `VBoxManage snapshot VM_NAME list --machinereadable` output:
+        # SnapshotName="ROOT"
+        # SnapshotUUID="86b38fc9-9d68-4e4b-a033-4075002ab570"
+        # SnapshotName-1="Snapshot 1"
+        # SnapshotUUID-1="e383e702-fee3-4e0b-b1e0-f3b869dbcaea"
+        # CurrentSnapshotName="Snapshot 1"
+        # CurrentSnapshotUUID="e383e702-fee3-4e0b-b1e0-f3b869dbcaea"
+        # CurrentSnapshotNode="SnapshotName-1"
+        # SnapshotName-1-1="Snapshot 2"
+        # SnapshotUUID-1-1="8cc12787-99df-466e-8a51-80e373d3447a"
+        # SnapshotName-2="Snapshot 3"
+        # SnapshotUUID-2="f42533a8-7c14-4855-aa66-7169fe8187fe"
+        #
+        # ROOT
+        #   ├─ Snapshot 1
+        #   │   └─ Snapshot 2
+        #   └─ Snapshot 3
 
         snapshots_info = run_vboxmanage(["snapshot", vm_name, "list", "--machinereadable"])
         # Find all snapshot names
-        snapshot_regex = rf"(SnapshotName(?:-\d+)*)=\"(.*?)\""
+        snapshot_regex = rf"(^SnapshotName(?:-\d+)*)=\"(.*?)\""
         snapshots = re.findall(snapshot_regex, snapshots_info, flags=re.M)
 
         children = []

--- a/virtualbox/vbox-clean-snapshots.py
+++ b/virtualbox/vbox-clean-snapshots.py
@@ -69,22 +69,13 @@ def get_snapshot_children(vm_name, root_snapshot_name, protected_snapshots):
             raise Exception(f"Failed to find root snapshot {snapshot_name}")
 
         # children of that snapshot share the same prefix id
-        dependant_child = False
         for snapshotid, snapshot_name in snapshots:
             if snapshotid.startswith(root_snapshotid):
                 if not any(
                     p.lower() in snapshot_name.lower() for p in protected_snapshots
                 ):
                     children.append((snapshotid, snapshot_name))
-                else:
-                    dependant_child = True
 
-        # remove the root snapshot if any children are protected OR it's the current snapshot
-        if dependant_child:
-            print("Root snapshot cannot be deleted as a child snapshot is protected")
-            children = [
-                snapshot for snapshot in children if snapshot[0] != root_snapshotid
-            ]
         return children
     except Exception as e:
         raise Exception(f"Could not get snapshot children for '{vm_name}'") from e
@@ -104,17 +95,17 @@ def delete_snapshot_and_children(vm_name, snapshot_name, protected_snapshots):
                 f"\nVM state: {vm_state}\n⚠️  Snapshot deleting is slower in a running VM and may fail in a changing state"
             )
 
-        answer = input("\nConfirm deletion (press 'y'):")
+        answer = input("\nConfirm deletion (press 'y'): ")
         if answer.lower() == "y":
-            print("\nDeleting... (this may take some time, go for an 🍦!)")
+            print("\nDELETING SNAPSHOTS... (this may take some time, go for an 🍦!)")
             for snapshotid, snapshot_name in reversed(
                 snaps_to_delete
             ):  # delete in reverse order to avoid issues with child snapshots
                 try:
                     run_vboxmanage(["snapshot", vm_name, "delete", snapshot_name])
-                    print(f"  🫧 DELETED '{snapshot_name}'")
+                    print(f"🫧 DELETED '{snapshot_name}'")
                 except Exception as e:
-                    print(f"  ❌ ERROR '{snapshot_name}'\n{e}")
+                    print(f"❌ ERROR '{snapshot_name}'\n{e}")
     else:
         print(f"\n{vm_name} is clean 🫧")
 

--- a/virtualbox/vbox-clean-snapshots.py
+++ b/virtualbox/vbox-clean-snapshots.py
@@ -64,7 +64,6 @@ def get_snapshot_children(vm_name, root_snapshot_name, protected_snapshots):
                 root_snapshotid = snapshotid
 
         if not root_snapshotid:
-            print("Failed to find root snapshot")
             raise Exception(f"Failed to find root snapshot {snapshot_name}")
 
         # children of that snapshot share the same prefix id

--- a/virtualbox/vbox-clean-snapshots.py
+++ b/virtualbox/vbox-clean-snapshots.py
@@ -23,7 +23,7 @@ from vboxcommon import *
 
 
 def get_snapshot_children(vm_name, root_snapshot_name, protected_snapshots):
-    """Recursively gets the children of a snapshot using 'VBoxManage showvminfo'.
+    """Get the children of a snapshot (including the snapshot) using 'VBoxManage snapshot' with the 'list' option.
 
     Args:
       vm_name: The name of the VM.
@@ -48,10 +48,10 @@ def get_snapshot_children(vm_name, root_snapshot_name, protected_snapshots):
         #   └─ Child1SnapshotTesting
         # Current State
 
-        vminfo = run_vboxmanage(["showvminfo", vm_name, "--machinereadable"])
+        snapshots_info = run_vboxmanage(["snapshot", vm_name, "list", "--machinereadable"])
         # Find all snapshot names
         snapshot_regex = rf"(SnapshotName(?:-\d+)*)=\"(.*?)\""
-        snapshots = re.findall(snapshot_regex, vminfo, flags=re.M)
+        snapshots = re.findall(snapshot_regex, snapshots_info, flags=re.M)
 
         children = []
 


### PR DESCRIPTION
The following PR fixes the following **bugs**:
- **A snapshot outside root may be deleted if it has the same name as one inside root**.Use the snapshot ID instead of the name to fix the issue.
-  **The root snapshot argument should be optional and case sensitive**.  Make clear that this is the case and use all snapshots if no root snapshot is provided instead of raising an exception.
- **Duplicated current snapshot**. The current code may include the current snapshot twice, which causes that
a confusing output is rendered and that the snapshot is being removed twice (failing the second time).
- **Root snapshot is not deleted if a child is protected, but it is possible to delete a root snapshot with a single protected child.** It is not possible to delete the root snapshot if it has more than one protected child. But this issue happens at every level, not only at the root snapshot. The inconsistent behavior is confusing and complicates the code unnecessarily. Instead, try to always delete non protected snapshots (including the root snapshot) and improve the rendered error output.
- **Protected root snapshot is not supported**. The root snapshot can be protected, so that its children get deleted but not the root snapshot. 

In addition, the PR includes other improvements, such as better exception handling and using more specific VBoxManage commands. **See the detailed commit messages for more details on every of the changes**.