### PR TITLE
Improve vboxcommon

### DIFF
--- a/virtualbox/vbox-export-snapshots.py
+++ b/virtualbox/vbox-export-snapshots.py
@@ -80,24 +80,24 @@ def get_vm_uuid(vm_name):
         raise Exception(f"Could not find VM '{vm_name}'") from e
 
 
-def change_network_adapters_to_hostonly(machine_guid):
+def change_network_adapters_to_hostonly(vm_uuid):
     """Changes all active network adapters to Host-Only. Must be poweredoff"""
     ensure_hostonlyif_exists()
     try:
         # disable all the nics to get to a clean state
-        vminfo = run_vboxmanage(["showvminfo", machine_guid, "--machinereadable"])
+        vminfo = run_vboxmanage(["showvminfo", vm_uuid, "--machinereadable"])
         for nic_number, nic_value in re.findall(
             '^nic(\d+)="(\S+)"', vminfo, flags=re.M
         ):
             if nic_value != "none":  # Ignore NICs with value "none"
-                run_vboxmanage(["modifyvm", machine_guid, f"--nic{nic_number}", "none"])
+                run_vboxmanage(["modifyvm", vm_uuid, f"--nic{nic_number}", "none"])
                 print(f"Changed nic{nic_number}")
 
         # set first nic to hostonly
-        run_vboxmanage(["modifyvm", machine_guid, f"--nic1", "hostonly"])
+        run_vboxmanage(["modifyvm", vm_uuid, f"--nic1", "hostonly"])
 
         # ensure changes applied
-        vminfo = run_vboxmanage(["showvminfo", machine_guid, "--machinereadable"])
+        vminfo = run_vboxmanage(["showvminfo", vm_uuid, "--machinereadable"])
         for nic_number, nic_value in re.findall(
             '^nic(\d+)="(\S+)"', vminfo, flags=re.M
         ):
@@ -119,8 +119,8 @@ def change_network_adapters_to_hostonly(machine_guid):
         raise Exception("Failed to change VM network adapters to hostonly") from e
 
 
-def restore_snapshot(machine_guid, snapshot_name):
-    status = run_vboxmanage(["snapshot", machine_guid, "restore", snapshot_name])
+def restore_snapshot(vm_uuid, snapshot_name):
+    status = run_vboxmanage(["snapshot", vm_uuid, "restore", snapshot_name])
     print(f"Restored '{snapshot_name}'")
     return status
 

--- a/virtualbox/vboxcommon.py
+++ b/virtualbox/vboxcommon.py
@@ -76,15 +76,16 @@ def ensure_hostonlyif_exists():
 
 
 def get_vm_state(vm_uuid):
-    """Gets the VM state using 'VBoxManage showvminfo'."""
+    """Get the VM state using 'VBoxManage showvminfo'."""
+    # Example of `VBoxManage showvminfo <VM_UUID> --machinereadable` relevant output:
     # VMState="poweroff"
-    # VMStateChangeTime="2025-01-02T16:31:51.000000000"
+    vm_info = run_vboxmanage(["showvminfo", vm_uuid, "--machinereadable"])
 
-    vminfo = run_vboxmanage(["showvminfo", vm_uuid, "--machinereadable"])
-    for line in vminfo.splitlines():
-        if line.startswith("VMState"):
-            return line.split("=")[1].strip('"')
-    raise Exception(f"Could not start VM '{vm_uuid}'")
+    match = re.search(f'^VMState="(?P<state>\S+)"', vm_info, flags=re.M)
+    if match:
+        return match["state"]
+
+    raise Exception(f"Unable to get state of VM {vm_uuid}")
 
 
 def wait_until_vm_state(vm_uuid, target_state):

--- a/virtualbox/vboxcommon.py
+++ b/virtualbox/vboxcommon.py
@@ -23,12 +23,14 @@ def format_arg(arg):
         return f"'{arg}'"
     return arg
 
+
 def cmd_to_str(cmd):
     """Convert a list of string arguments to a string."""
     return " ".join(format_arg(arg) for arg in cmd)
 
+
 def run_vboxmanage(cmd):
-    """Runs a VBoxManage command and returns the output.
+    """Run a VBoxManage command and return the output.
 
     Args:
       cmd: list of string arguments to pass to VBoxManage
@@ -40,9 +42,9 @@ def run_vboxmanage(cmd):
         # Use only the first "VBoxManage: error:" line to prevent using the long
         # VBoxManage help message or noisy information like the details and context.
         error = f"Command '{cmd_to_str(cmd)}' failed"
-        stderr_info = re.search("^VBoxManage: error: (.*)", result.stderr, flags=re.M)
-        if stderr_info:
-            error += f": {stderr_info.group(1)}"
+        match = re.search("^VBoxManage: error: (?P<stderr_info>.*)", result.stderr, flags=re.M)
+        if match:
+            error += f": {match['stderr_info']}"
         raise RuntimeError(error)
 
     return result.stdout
@@ -57,6 +59,7 @@ def get_hostonlyif_name():
     match = re.search(f"^Name: *(?P<hostonlyif_name>\S+)", hostonlyifs_info, flags=re.M)
     if match:
         return match["hostonlyif_name"]
+
 
 def ensure_hostonlyif_exists():
     """Get the name of the host-only interface. Create the interface if it doesn't exist."""
@@ -134,4 +137,3 @@ def ensure_vm_shutdown(vm_uuid):
 
     if not wait_until_vm_state(vm_uuid, "poweroff"):
         raise RuntimeError(f"Unable to shutdown VM {vm_uuid}.")
-


### PR DESCRIPTION
Improve `vboxcommon.py`, including:
- Enhance, make consistent and remove duplication in `ensure_vm_running` and `ensure_vm_shutdown` by introducing `wait_until_vm_state`. Remove the waiting time of 2 minutes after calling `ensure_vm_running` from `ensure_vm_shutdown` when the state is `saved, as `ensure_vm_running` already waits for the state to change to `running`.
- Enhance `ensure_hostonlyif_exists` by introducing `get_hostonlyif_name` to avoid duplication.
- Parse the VBoxManage output with regular expressions for consistency and to improve code readability. 
- Remove noisy output and make the output consistent to make easier to call vboxcommon functions from other scripts displaying a nice output.
- Remove unneeded use of exceptions re-raising.

Also rename  variables in `vbox-adapter-check.py` and `vboxcommon.py` for consistency with VBoxManage and the other vbox scripts.

See the detailed commit messages for more details.