### PR TITLE
Improve vbox-export-snapshots.py

### DIFF
--- a/virtualbox/README.md
+++ b/virtualbox/README.md
@@ -9,11 +9,13 @@ It also generates a file with the SHA256 hash of the exported `.ova`.
 This script is useful to export several versions of FLARE-VM after its installation consistently and with the internet disabled by default (desired for malware analysis).
 For example, you may want to export a VM with the default FLARE-VM configuration and another installing in addition the packages `visualstudio.vm` and `pdbs.pdbresym.vm`.
 These packages are useful for malware analysis but are not included in the default configuration because of the consequent increase in size.
+The scripts receives the path of the JSON configuration file as argument.
+See configuration example files in the [`configs`](configs/) directory.
 
 ### Example
 
 ```
-$ ./vbox-export-snapshots.py "FLARE-VM.testing" --snapshot "FLARE-VM,.dynamic,Windows 10 VM with FLARE-VM default configuration" --snapshot "FLARE-VM.full,.full.dynamic,Windows 10 VM with FLARE-VM default configuration + 'visualstudio.vm' + 'pdbs.pdbresym.vm'"
+$ ./vbox-export-snapshots.py configs/export_win10_flare-vm.json
 
 Exporting snapshots from "FLARE-VM.testing" {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d}
 Export directory: "/home/anamg/EXPORTED VMS"

--- a/virtualbox/README.md
+++ b/virtualbox/README.md
@@ -4,12 +4,36 @@
 
 ## Export snapshots
 
-[`vbox-export-snapshots.py`](vbox-export-snapshots.py) export one or more snapshots in the same VirtualBox virtual machine (VM) as `.ova`, changing the network adapter to Host-Only.
+[`vbox-export-snapshots.py`](vbox-export-snapshots.py) export one or more snapshots in the same VirtualBox VM as .ova, changing the network to a single Host-Only interface.
 It also generates a file with the SHA256 hash of the exported `.ova`.
 This script is useful to export several versions of FLARE-VM after its installation consistently and with the internet disabled by default (desired for malware analysis).
 For example, you may want to export a VM with the default FLARE-VM configuration and another installing in addition the packages `visualstudio.vm` and `pdbs.pdbresym.vm`.
 These packages are useful for malware analysis but are not included in the default configuration because of the consequent increase in size.
 
+### Example
+
+```
+$ ./vbox-export-snapshots.py "FLARE-VM.testing" --snapshot "FLARE-VM,.dynamic,Windows 10 VM with FLARE-VM default configuration" --snapshot "FLARE-VM.full,.full.dynamic,Windows 10 VM with FLARE-VM default configuration + 'visualstudio.vm' + 'pdbs.pdbresym.vm'"
+
+Exporting snapshots from "FLARE-VM.testing" {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d}
+Export directory: "/home/anamg/EXPORTED VMS"
+
+VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} state: running. Shutting down VM...
+VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ✨ restored snapshot "FLARE-VM"
+VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} state: saved. Starting VM...
+VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} state: running. Shutting down VM...
+VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ⚙️  network set to single hostonly adapter
+VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} 🔄 power cycling before export... (it will take some time, go for an 🍦!)
+VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} state: poweroff. Starting VM...
+VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} state: running. Shutting down VM...
+VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} 🚧 exporting "FLARE-VM.20250129.dynamic"... (it will take some time, go for an 🍦!)
+VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ✅ EXPORTED "/home/anamg/EXPORTED VMS/FLARE-VM.20250129.dynamic.ova"
+VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ✅ GENERATED "/home/anamg/EXPORTED VMS/FLARE-VM.20250129.dynamic.ova.sha256": 73c3de4175449987ef6047f6e0bea91c1036a8599b43113b3f990104ab294a47
+
+VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ❌ ERROR exporting "FLARE-VM.full":Command 'VBoxManage snapshot {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} restore FLARE-VM.full' failed: Could not find a snapshot named 'FLARE-VM.full'
+
+Done! 🙃
+```
 
 ## Check internet adapter status
 

--- a/virtualbox/configs/export_remnux.json
+++ b/virtualbox/configs/export_remnux.json
@@ -1,0 +1,11 @@
+{
+  "VM_NAME": "REMnux.testing",
+  "EXPORTED_VM_NAME": "REMnux",
+  "SNAPSHOTS": [
+    [
+      "DONE",
+      ".dynamic",
+      "REMnux (based on Ubuntu) with improved configuration"
+    ]
+  ]
+}

--- a/virtualbox/configs/export_win10_flare-vm.json
+++ b/virtualbox/configs/export_win10_flare-vm.json
@@ -1,0 +1,21 @@
+{
+  "VM_NAME": "FLARE-VM.testing",
+  "EXPORTED_VM_NAME": "FLARE-VM",
+  "SNAPSHOTS": [
+    [
+      "FLARE-VM",
+      ".dynamic",
+      "Windows 10 VM with FLARE-VM default configuration"
+    ],
+    [
+      "FLARE-VM.full",
+      ".full.dynamic",
+      "Windows 10 VM with FLARE-VM default configuration + visualstudio.vm + pdbs.pdbresym.vm + microsoft-office.vm"
+    ],
+    [
+      "FLARE-VM.EDU",
+      ".EDU",
+      "Windows 10 VM with FLARE-VM default configuration + FLARE-EDU materials"
+    ]
+  ]
+}

--- a/virtualbox/configs/export_win11_flare-vm.json
+++ b/virtualbox/configs/export_win11_flare-vm.json
@@ -1,0 +1,16 @@
+{
+  "VM_NAME": "FLARE-VM.Win11.testing",
+  "EXPORTED_VM_NAME": "FLARE-VM",
+  "SNAPSHOTS": [
+    [
+      "FLARE-VM",
+      ".win11.dynamic",
+      "Windows 11 VM with FLARE-VM default configuration"
+    ],
+    [
+      "FLARE-VM.full",
+      "win11.full.dynamic",
+      "Windows 11 VM with FLARE-VM default configuration + visualstudio.vm + pdbs.pdbresym.vm + microsoft-office.vm"
+    ]
+  ]
+}

--- a/virtualbox/vbox-export-snapshots.py
+++ b/virtualbox/vbox-export-snapshots.py
@@ -163,9 +163,14 @@ if __name__ == "__main__":
             time.sleep(POWER_CYCLE_TIME)
             ensure_vm_shutdown(vm_uuid)
 
-            # Export .ova
             exported_vm_name = f"{EXPORTED_VM_NAME}.{date}{extension}"
             exported_ova_filepath = os.path.join(export_directory, f"{exported_vm_name}.ova")
+
+            # Provide better error if OVA already exists (for example if the script is called twice)
+            if os.path.exists(exported_ova_filepath):
+                raise FileExistsError(f'"{exported_ova_filepath}" already exists')
+
+            # Export .ova
             print(f'VM {vm_uuid} 🚧 exporting "{exported_vm_name}"{LONG_WAIT}')
             run_vboxmanage(
                 [

--- a/virtualbox/vbox-export-snapshots.py
+++ b/virtualbox/vbox-export-snapshots.py
@@ -58,6 +58,10 @@ SNAPSHOTS = [
     ),
 ]
 
+# Duration of the power cycle: the seconds we wait between starting the VM and powering it off.
+# It should be long enough for the internet_detector to detect the network change.
+POWER_CYCLE_TIME = 240  # 4 minutes
+
 
 def sha256_file(filename):
     with open(filename, "rb") as f:
@@ -142,14 +146,12 @@ if __name__ == "__main__":
 
             set_network_to_hostonly(vm_uuid)
 
-            # do a power cycle to ensure everything is good
-            print("Power cycling before export...")
-
-            # TODO: Add a guest notifier (read: run a script in the guest) to say when windows boots, only then shutdown.
-            # this works right now but it's a hardcoded sleep which wasts time and isn't guaranteed to not race. Fine for now.
+            # Do a power cycle to ensure everything is good and
+            # give the internet detector time to detect the network change
+            print(f"VM {vm_uuid} 🔄 power cycling before export... (it will take some time, go for an 🍦!)")
             ensure_vm_running(vm_uuid)
+            time.sleep(POWER_CYCLE_TIME)
             ensure_vm_shutdown(vm_uuid)
-            print("Power cycling done.")
 
             # Export .ova
             exported_vm_name = f"{EXPORTED_VM_NAME}.{date}{extension}"

--- a/virtualbox/vbox-export-snapshots.py
+++ b/virtualbox/vbox-export-snapshots.py
@@ -140,6 +140,12 @@ if __name__ == "__main__":
         exit()
 
     print(f'Exporting snapshots from "{VM_NAME}" {vm_uuid}')
+
+    # Create export directory
+    export_directory = os.path.expanduser(f"~/{EXPORT_DIR_NAME}")
+    os.makedirs(export_directory, exist_ok=True)
+    print(f'Export directory: "{export_directory}"\n')
+
     for snapshot_name, extension, description in SNAPSHOTS:
         try:
             restore_snapshot(vm_uuid, snapshot_name)
@@ -155,10 +161,7 @@ if __name__ == "__main__":
 
             # Export .ova
             exported_vm_name = f"{EXPORTED_VM_NAME}.{date}{extension}"
-            export_directory = os.path.expanduser(f"~/{EXPORT_DIR_NAME}")
-            os.makedirs(export_directory, exist_ok=True)
             filename = os.path.join(export_directory, f"{exported_vm_name}.ova")
-
             print(f"Exporting {filename} (this will take some time, go for an 🍦!)")
             run_vboxmanage(
                 [

--- a/virtualbox/vbox-export-snapshots.py
+++ b/virtualbox/vbox-export-snapshots.py
@@ -120,13 +120,12 @@ def change_network_adapters_to_hostonly(vm_uuid):
 
 
 def restore_snapshot(vm_uuid, snapshot_name):
-    """Restore snapshot"""
+    """Restore a given snapshot in the given VM."""
     # VM must be shutdown before restoring snapshot
     ensure_vm_shutdown(vm_uuid)
 
-    status = run_vboxmanage(["snapshot", vm_uuid, "restore", snapshot_name])
-    print(f"Restored '{snapshot_name}'")
-    return status
+    run_vboxmanage(["snapshot", vm_uuid, "restore", snapshot_name])
+    print(f'VM {vm_uuid} ✨ restored snapshot "{snapshot_name}"')
 
 
 if __name__ == "__main__":

--- a/virtualbox/vbox-export-snapshots.py
+++ b/virtualbox/vbox-export-snapshots.py
@@ -63,6 +63,10 @@ SNAPSHOTS = [
 POWER_CYCLE_TIME = 240  # 4 minutes
 
 
+# Message to add to the output when waiting for a long operation to complete.
+LONG_WAIT = "... (it will take some time, go for an 🍦!)"
+
+
 def sha256_file(filename):
     with open(filename, "rb") as f:
         return hashlib.file_digest(f, "sha256").hexdigest()
@@ -139,7 +143,7 @@ if __name__ == "__main__":
         print(f'ERROR: "{VM_NAME}" not found')
         exit()
 
-    print(f'Exporting snapshots from "{VM_NAME}" {vm_uuid}')
+    print(f'\nExporting snapshots from "{VM_NAME}" {vm_uuid}')
 
     # Create export directory
     export_directory = os.path.expanduser(f"~/{EXPORT_DIR_NAME}")
@@ -154,33 +158,35 @@ if __name__ == "__main__":
 
             # Do a power cycle to ensure everything is good and
             # give the internet detector time to detect the network change
-            print(f"VM {vm_uuid} 🔄 power cycling before export... (it will take some time, go for an 🍦!)")
+            print(f"VM {vm_uuid} 🔄 power cycling before export{LONG_WAIT}")
             ensure_vm_running(vm_uuid)
             time.sleep(POWER_CYCLE_TIME)
             ensure_vm_shutdown(vm_uuid)
 
             # Export .ova
             exported_vm_name = f"{EXPORTED_VM_NAME}.{date}{extension}"
-            filename = os.path.join(export_directory, f"{exported_vm_name}.ova")
-            print(f"Exporting {filename} (this will take some time, go for an 🍦!)")
+            exported_ova_filepath = os.path.join(export_directory, f"{exported_vm_name}.ova")
+            print(f'VM {vm_uuid} 🚧 exporting "{exported_vm_name}"{LONG_WAIT}')
             run_vboxmanage(
                 [
                     "export",
                     vm_uuid,
-                    f"--output={filename}",
+                    f"--output={exported_ova_filepath}",
                     "--vsys=0",  # We need to specify the index of the VM, 0 as we only export 1 VM
                     f"--vmname={exported_vm_name}",
                     f"--description={description}",
                 ]
             )
+            print(f'VM {vm_uuid} ✅ EXPORTED "{exported_ova_filepath}"')
 
             # Generate file with SHA256
-            with open(f"{filename}.sha256", "w") as f:
-                f.write(sha256_file(filename))
+            sha256 = sha256_file(exported_ova_filepath)
+            sha256_filepath = f"{exported_ova_filepath}.sha256"
+            with open(sha256_filepath, "w") as f:
+                f.write(sha256)
 
-            print(f"Exported {filename}! 🎉")
+            print(f'VM {vm_uuid} ✅ GENERATED "{sha256_filepath}": {sha256}\n')
         except Exception as e:
-            print(f"Unexpectedly failed doing operations on {VM_NAME}, snapshot ({snapshot_name}).\n{e}")
-            break
-        print(f"All operations on {VM_NAME}, snapshot ({snapshot_name}), successful ✅")
-    print("Done. Exiting...")
+            print(f'VM {vm_uuid} ❌ ERROR exporting "{snapshot_name}":{e}\n')
+
+    print("Done! 🙃")


### PR DESCRIPTION
Improve `vbox-export-snapshots.py`, including:
- **Continue exporting snapshots if one fails to export**
- **Receive the configuration information as arguments in `vbox-export-snapshots.py` instead of hardcode it in global variables**. This allows more flexibility when using the script without having to modify it. The command gets a bit long though. Let me know if you have any improvement idea. :wink: 
- **Do a power cycle to ensure everything is good and wait for 4 minutes to give the internet detector time to detect the network change**. A similar code was before in `ensure_vm_running`, but the waiting time only happened if the VM was in state `saved` when starting the shutdown. In addition, it unnecessarily delayed other functions that call this function. This is the change discussed with @stevemk14ebr in https://github.com/mandiant/flare-vm/pull/647#discussion_r1933386823.
- **Get the VM UUID and create the export directory only once** (instead of for every snapshot)
- **Move the calls to `ensure_vm_shutdown` inside the functions that require the VM to be shutdown** instead of having it as a pre-step for better code readability and preventing issues.
- **Improve output and error handling**.
- **Improve code readability and documentation**.

# Example

### After
With the changes in https://github.com/mandiant/flare-vm/pull/647 and in this PR.  Note we export an extra snapshot after one fails to export.

```
$ ./vbox-export-snapshots.py "FLARE-VM.testing" --snapshot "FLARE-VM,.dynamic,Windows 10 VM with FLARE-VM default configuration" --snapshot "FLARE-VM.full,.full.dynamic,Windows 10 VM with FLARE-VM default configuration + 'visualstudio.vm' + 'pdbs.pdbresym.vm'" --snapshot "FLARE-VM.EDU,.EDU,Windows 10 VM with FLARE-VM default configuration + FLARE-EDU materials"

Exporting snapshots from "FLARE-VM.testing" {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d}
Export directory: "/home/anamg/EXPORTED VMS"

VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ✨ restored snapshot "FLARE-VM"
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} state: saved. Starting VM...
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} state: running. Shutting down VM...
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ⚙️  network set to single hostonly adapter
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} 🔄 power cycling before export... (it will take some time, go for an 🍦!)
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} state: poweroff. Starting VM...
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} state: running. Shutting down VM...
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} 🚧 exporting "FLARE-VM.20250130.dynamic"... (it will take some time, go for an 🍦!)
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ✅ EXPORTED "/home/anamg/EXPORTED VMS/FLARE-VM.20250130.dynamic.ova"
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ✅ GENERATED "/home/anamg/EXPORTED VMS/FLARE-VM.20250130.dynamic.ova.sha256": 73c3de4175449987ef6047f6e0bea91c1036a8599b43113b3f990104ab294a47

VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ❌ ERROR exporting "FLARE-VM.full":Command 'VBoxManage snapshot {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} restore FLARE-VM.full' failed: Could not find a snapshot named 'FLARE-VM.full'

VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ✨ restored snapshot "FLARE-VM.EDU"
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ⚙️  network set to single hostonly adapter
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} 🔄 power cycling before export... (it will take some time, go for an 🍦!)
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} state: poweroff. Starting VM...
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} state: running. Shutting down VM...
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} 🚧 exporting "FLARE-VM.20250130.dynamic.20250130.EDU"... (it will take some time, go for an 🍦!)
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ✅ EXPORTED "/home/anamg/EXPORTED VMS/FLARE-VM.20250130.dynamic.20250130.EDU.ova"
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ✅ GENERATED "/home/anamg/EXPORTED VMS/FLARE-VM.20250130.dynamic.20250130.EDU.ova.sha256": 73c3de4175449987ef6047f6e0bea91c1036a8599b43113b3f990104ab294a47

Done! 🙃
```

### Before
Before https://github.com/mandiant/flare-vm/pull/647 and this PR. Note one snapshot fails to export and the following one is not exported, making the output shorter.
```
$ ./vbox-export-snapshots.py 
Starting operations on FLARE-VM
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} is already shut down (state: poweroff).
Restored 'FLARE-VM'
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} is in a saved state. Powering on for a while then shutting down...
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} is not running (state: saved). Starting VM...
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} started.
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} is not powered off. Shutting down VM...
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} is shut down (status: poweroff).
Found existing hostonlyif vboxnet0
Changed nic2
Nic configuration verified correct
Power cycling before export...
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} is not running (state: poweroff). Starting VM...
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} started.
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} is not powered off. Shutting down VM...
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} is shut down (status: poweroff).
Power cycling done.
Exporting /home/anamg/EXPORTED VMS/FLARE-VM.20250130.dynamic.ova (this will take some time, go for an 🍦!)
Exported /home/anamg/EXPORTED VMS/FLARE-VM.20250130.dynamic.ova! 🎉
All operations on FLARE-VM.testing, snapshot (FLARE-VM), successful ✅
Starting operations on FLARE-VM.full
VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} is already shut down (state: poweroff).
Unexpectedly failed doing operations on FLARE-VM.testing, snapshot (FLARE-VM.full).
COMMAND FAILED: VBoxManage snapshot {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} restore FLARE-VM.full
VBoxManage: error: Could not find a snapshot named 'FLARE-VM.full'
Done. Exiting...
```