### PR TITLE
[ci] Run black

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,18 @@
+name: Linter
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  lint:
+    runs-on: windows-2022
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Install black
+        run: pip install black
+      - name: Run black
+        run: black --line-length=120 --check --diff .

--- a/virtualbox/vbox-adapter-check.py
+++ b/virtualbox/vbox-adapter-check.py
@@ -51,9 +51,7 @@ def get_vm_uuids(dynamic_only):
     return vm_uuids
 
 
-def change_network_adapters_to_hostonly(
-    vm_uuid, vm_name, hostonly_ifname, do_not_modify
-):
+def change_network_adapters_to_hostonly(vm_uuid, vm_name, hostonly_ifname, do_not_modify):
     """Verify all adapters are in an allowed configuration. Must be poweredoff"""
     try:
         # gather adapters in incorrect configurations
@@ -72,9 +70,7 @@ def change_network_adapters_to_hostonly(
         # nic8="none"
 
         vminfo = run_vboxmanage(["showvminfo", vm_uuid, "--machinereadable"])
-        for nic_number, nic_value in re.findall(
-            '^nic(\d+)="(\S+)"', vminfo, flags=re.M
-        ):
+        for nic_number, nic_value in re.findall('^nic(\d+)="(\S+)"', vminfo, flags=re.M):
             if nic_value not in ALLOWED_ADAPTER_TYPES:
                 nics_with_internet.append(f"nic{nic_number}")
                 invalid_nics_msg += f"{nic_number} "
@@ -115,9 +111,7 @@ def change_network_adapters_to_hostonly(
 
             # Show notification using PyGObject
             Notify.init("VirtualBox adapter check")
-            notification = Notify.Notification.new(
-                f"INTERNET IN VM: {vm_name}", message, "dialog-error"
-            )
+            notification = Notify.Notification.new(f"INTERNET IN VM: {vm_name}", message, "dialog-error")
             # Set highest priority
             notification.set_urgency(2)
             notification.show()
@@ -167,9 +161,7 @@ def main(argv=None):
         vm_uuids = get_vm_uuids(args.dynamic_only)
         if len(vm_uuids) > 0:
             for vm_name, vm_uuid in vm_uuids:
-                change_network_adapters_to_hostonly(
-                    vm_uuid, vm_name, hostonly_ifname, args.do_not_modify
-                )
+                change_network_adapters_to_hostonly(vm_uuid, vm_name, hostonly_ifname, args.do_not_modify)
         else:
             print(f"[Warning ⚠️] No VMs found")
     except Exception as e:

--- a/virtualbox/vbox-clean-snapshots.py
+++ b/virtualbox/vbox-clean-snapshots.py
@@ -26,6 +26,7 @@ def is_protected(protected_snapshots, snapshot_name):
     """Check if snapshot_name contains any of the strings in the protected_snapshots list (case insensitive)"""
     return any(p.lower() in snapshot_name.lower() for p in protected_snapshots)
 
+
 def get_snapshot_children(vm_name, root_snapshot_name, protected_snapshots):
     """Get the children of a snapshot (including the snapshot) using 'VBoxManage snapshot' with the 'list' option.
 
@@ -149,9 +150,7 @@ def main(argv=None):
     )
     args = parser.parse_args(args=argv)
 
-    delete_snapshot_and_children(
-        args.vm_name, args.root_snapshot, args.protected_snapshots
-    )
+    delete_snapshot_and_children(args.vm_name, args.root_snapshot, args.protected_snapshots)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Run black code formatter using GH actions to ensure style consistency in our Python files. Run it on main and in every PR.

Run black to fix the current issues in `vbox-adapter-check.py` and `vbox-clean-snapshots.py`. Do not fix issues in `vbox-export-snapshots.py` as they are fixed already by https://github.com/mandiant/flare-vm/pull/649 and it would cause merge conflicts. Wait for that PR to merge this one, so that we also see black failing. :wink: 

Partially addresses (PS and other Python linters in follow-up PRs): https://github.com/mandiant/flare-vm/issues/507