### PR TITLE
[ci] Run isort

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -12,7 +12,10 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - name: Install black
-        run: pip install black
+      - name: Install dependencies
+        run: pip install black isort
       - name: Run black
         run: black --line-length=120 --check --diff .
+      - name: Run isort
+        run: isort --check --diff .
+

--- a/virtualbox/vbox-adapter-check.py
+++ b/virtualbox/vbox-adapter-check.py
@@ -23,7 +23,6 @@ import gi
 
 gi.require_version("Notify", "0.7")
 from gi.repository import Notify
-
 from vboxcommon import *
 
 DYNAMIC_VM_NAME = ".dynamic"


### PR DESCRIPTION
Add running isort to the CI to ensure consistent library import in Python files. Run isort to fix the current issues in `vbox-adapter-check.py`.

Partially addresses (PS and flake8 in follow-up PRs): https://github.com/mandiant/flare-vm/issues/507