### PR TITLE
[config] Remove microsoft-office.vm & add ida.plugin.hrtng.vm

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -86,7 +86,6 @@
         <package name="magika.vm"/>
         <package name="malware-jail.vm"/>
         <package name="map.vm"/>
-        <package name="microsoft-office.vm"/>
         <package name="nasm.vm"/>
         <package name="net-reactor-slayer.vm"/>
         <package name="notepadplusplus.vm"/>

--- a/config.xml
+++ b/config.xml
@@ -67,6 +67,7 @@
         <package name="ida.plugin.dereferencing.vm"/>
         <package name="ida.plugin.diaphora.vm"/>
         <package name="ida.plugin.flare.vm"/>
+        <package name="ida.plugin.hrtng.vm"/>
         <package name="ida.plugin.ifl.vm"/>
         <package name="ida.plugin.xray.vm"/>
         <package name="ida.plugin.xrefer.vm"/>


### PR DESCRIPTION
- Remove microsoft-office.vm as it only provides 5 days trial and makes it confusing when installing another Office version. It can still be installed using a custom config file or selecting it via the GUI.
- Add the recently created package ida.plugin.hrtng.vm for the hrtng IDA plugin.