### PR TITLE
Add flake8 linter & fix conflict between isort and black

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -17,5 +17,5 @@ jobs:
       - name: Run black
         run: black --line-length=120 --check --diff .
       - name: Run isort
-        run: isort --check --diff .
+        run: isort --check --diff --line-length 120 .
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -13,9 +13,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install dependencies
-        run: pip install black isort
+        run: pip install black isort flake8
+      # Different line limits: Black/isort (120), Flake8 (150). 
+      # Flake8 allows longer lines for better long string readability. Black doesn't enforce string length.
       - name: Run black
         run: black --line-length=120 --check --diff .
+      - name: Run flake8
+        run: flake8 --max-line-length 150
       - name: Run isort
         run: isort --check --diff --line-length 120 .
 

--- a/virtualbox/vbox-export-snapshots.py
+++ b/virtualbox/vbox-export-snapshots.py
@@ -20,12 +20,14 @@ import os
 import re
 import sys
 import textwrap
+import time
 from datetime import datetime
 
 import jsonschema
-from vboxcommon import *
+from vboxcommon import ensure_hostonlyif_exists, ensure_vm_running, ensure_vm_shutdown, run_vboxmanage
 
-DESCRIPTION = "Export one or more snapshots in the same VirtualBox VM as .ova, changing the network to a single Host-Only interface. Generate a file with the SHA256 of the exported OVA(s)."
+DESCRIPTION = """Export one or more snapshots in the same VirtualBox VM as .ova, changing the network to a single Host-Only interface.
+Generate a file with the SHA256 of the exported OVA(s)."""
 
 EPILOG = textwrap.dedent(
     """
@@ -201,20 +203,18 @@ def main(argv=None):
     )
     parser.add_argument(
         "config_path",
-        help=textwrap.dedent(
-            """
-           path of the JSON configuration file.
+        help=""" path of the JSON configuration file.
              "VM_NAME" is the name of the VM to export snapshots from.
                Example: "FLARE-VM.testing".
              "EXPORTED_VM_NAME" is the name of the exported VMs.
                Example: "FLARE-VM".
-             "SNAPSHOTS" is a list of lists with information of the snapshots to export: ["SNAPSHOT_NAME", "EXPORTED_VM_EXTENSION", "DESCRIPTION"].
+             "SNAPSHOTS" is a list of lists with information of the snapshots to export:
+               ["SNAPSHOT_NAME", "EXPORTED_VM_EXTENSION", "DESCRIPTION"].
                Example: ["FLARE-VM", ".dynamic", "Windows 10 VM with FLARE-VM default configuration"].
              "EXPORT_DIR_NAME" (optional) is the name of the directory in HOME to export the VMs.
                The directory is created if it does not exist.
                Default: "EXPORTED VMS".
-           """
-        ),
+             """,
     )
     args = parser.parse_args(args=argv)
 

--- a/virtualbox/vboxcommon.py
+++ b/virtualbox/vboxcommon.py
@@ -56,7 +56,7 @@ def get_hostonlyif_name():
     # Name:            vboxnet0
     hostonlyifs_info = run_vboxmanage(["list", "hostonlyifs"])
 
-    match = re.search(f"^Name: *(?P<hostonlyif_name>\S+)", hostonlyifs_info, flags=re.M)
+    match = re.search(r"^Name: *(?P<hostonlyif_name>\S+)", hostonlyifs_info, flags=re.M)
     if match:
         return match["hostonlyif_name"]
 
@@ -73,7 +73,7 @@ def ensure_hostonlyif_exists():
         if not hostonlyif_name:
             raise RuntimeError("Failed to create new hostonly interface.")
 
-        print(f"VM {vm_uuid} Created hostonly interface: {hostonlyif_name}")
+        print(f"Hostonly interface created: {hostonlyif_name}")
 
     return hostonlyif_name
 
@@ -84,7 +84,7 @@ def get_vm_state(vm_uuid):
     # VMState="poweroff"
     vm_info = run_vboxmanage(["showvminfo", vm_uuid, "--machinereadable"])
 
-    match = re.search(f'^VMState="(?P<state>\S+)"', vm_info, flags=re.M)
+    match = re.search(r'^VMState="(?P<state>\S+)"', vm_info, flags=re.M)
     if match:
         return match["state"]
 


### PR DESCRIPTION
- Add max length of an import line to isort to avoid conflicts with black.
- Add flake8 linter to CI to improve code quality and maintainability.
- Fix flake8 offenses identified by the linter.
- Standardizee the formatting of multiline strings across all scripts, ensuring consistency and improved readability.