### PR TITLE
Fix black & isort incompability (again) & standardize linter line-length arguments 

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Run black
         run: black --line-length=120 --check --diff .
       - name: Run flake8
-        run: flake8 --max-line-length 150
+        run: flake8 --max-line-length=150
       - name: Run isort
-        run: isort --check --diff --profile black --line-length 120 .
+        run: isort --check --diff --profile black --line-length=120 .
 

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,5 +21,5 @@ jobs:
       - name: Run flake8
         run: flake8 --max-line-length 150
       - name: Run isort
-        run: isort --check --diff --line-length 120 .
+        run: isort --check --diff --profile black --line-length 120 .
 


### PR DESCRIPTION
In https://github.com/mandiant/flare-vm/pull/653/commits/ba2e1ef80692fd2ddd86f39d04f4043f16cd853a I set a consistent maximum line length in isort and black to try to address the conflicts when formatting long import lines But it is insufficient because isort and black format these lines differently. This PR resolves the issue by configuring isort to use the black profile (`--profile black`). This ensures consistent formatting and avoid conflicts.

Additionally, this PR standardizes the way the maximum line length argument is passed to all linters, using the `--<argument_name>=<number>` format consistently.

### Incompatibility example

#### `isort --line-length 120` (without `--profile black`)
```
from vboxcommon import (ensure_hostonlyif_exists, ensure_vm_running, ensure_vm_shutdown, get_vm_uuid, restore_snapshot,
                        run_vboxmanage)
```

#### `black --line-length=120`
```
from vboxcommon import (
    ensure_hostonlyif_exists,
    ensure_vm_running,
    ensure_vm_shutdown,
    get_vm_uuid,
    restore_snapshot,
    run_vboxmanage,
)
```

