### PR TITLE
Add script to install FLARE-VM in a guest VM

### DIFF
--- a/virtualbox/README.md
+++ b/virtualbox/README.md
@@ -130,5 +130,9 @@ Done! 🙃
 
 ## Build FLARE-VM
 
-[`vbox-build-flare-vm.py`](vbox-build-flare-vm.py) prepares a VirtualBox VM for building FLARE-VM.
-
+[`vbox-build-flare-vm.py`](vbox-build-flare-vm.py) restores a `BUILD-READY` snapshot, copies files required for the installation (like the IDA Pro installer and the FLARE-VM configuration file) and starts the FLARE-VM installation.
+The `BUILD-READY` snapshot is expected to be an empty Windows installation that satisfies the FLARE-VM installation requirements and has UAC disabled
+To disable UAC execute in a cmd console with admin rights and restart the VM for the change to take effect:
+```
+%windir%\System32\reg.exe ADD HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System /v EnableLUA /t REG_DWORD /d 0 /f
+```

--- a/virtualbox/README.md
+++ b/virtualbox/README.md
@@ -128,3 +128,7 @@ VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ❌ ERROR exporting "FLARE-VM.full":Co
 Done! 🙃
 ```
 
+## Build FLARE-VM
+
+[`vbox-build-flare-vm.py`](vbox-build-flare-vm.py) prepares a VirtualBox VM for building FLARE-VM.
+

--- a/virtualbox/README.md
+++ b/virtualbox/README.md
@@ -2,75 +2,6 @@
 
 **This folder contains several scripts related to enhance building, exporting, and using FLARE-VM in VirtualBox.**
 
-## Export snapshots
-
-[`vbox-export-snapshots.py`](vbox-export-snapshots.py) export one or more snapshots in the same VirtualBox VM as .ova, changing the network to a single Host-Only interface.
-It also generates a file with the SHA256 hash of the exported `.ova`.
-This script is useful to export several versions of FLARE-VM after its installation consistently and with the internet disabled by default (desired for malware analysis).
-For example, you may want to export a VM with the default FLARE-VM configuration and another installing in addition the packages `visualstudio.vm` and `pdbs.pdbresym.vm`.
-These packages are useful for malware analysis but are not included in the default configuration because of the consequent increase in size.
-The scripts receives the path of the JSON configuration file as argument.
-See configuration example files in the [`configs`](configs/) directory.
-
-### Example
-
-```
-$ ./vbox-export-snapshots.py configs/export_win10_flare-vm.json
-
-Exporting snapshots from "FLARE-VM.testing" {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d}
-Export directory: "/home/anamg/EXPORTED VMS"
-
-VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} state: running. Shutting down VM...
-VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ✨ restored snapshot "FLARE-VM"
-VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} state: saved. Starting VM...
-VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} state: running. Shutting down VM...
-VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ⚙️  network set to single hostonly adapter
-VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} 🔄 power cycling before export... (it will take some time, go for an 🍦!)
-VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} state: poweroff. Starting VM...
-VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} state: running. Shutting down VM...
-VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} 🚧 exporting "FLARE-VM.20250129.dynamic"... (it will take some time, go for an 🍦!)
-VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ✅ EXPORTED "/home/anamg/EXPORTED VMS/FLARE-VM.20250129.dynamic.ova"
-VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ✅ GENERATED "/home/anamg/EXPORTED VMS/FLARE-VM.20250129.dynamic.ova.sha256": 73c3de4175449987ef6047f6e0bea91c1036a8599b43113b3f990104ab294a47
-
-VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ❌ ERROR exporting "FLARE-VM.full":Command 'VBoxManage snapshot {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} restore FLARE-VM.full' failed: Could not find a snapshot named 'FLARE-VM.full'
-
-Done! 🙃
-```
-
-## Check internet adapter status
-
-[`vbox-adapter-check.py`](vbox-adapter-check.py) prints the status of all internet adapters of all VMs in VirtualBox.
-The script also notifies if any dynamic analysis VM (with `.dynamic` in the name) has an adapter whose type is not allowed (internet access is undesirable for dynamic malware analysis).
-Unless the argument `--do_not_modify` is provided, the script changes the type of the adapters with non-allowed type to Host-Only.
-Unless the argument `--skip_disabled` is provided, the script also explores the disabled adapters, printing their status and possibly changing their type.
-The script has been tested in Debian 12 with GNOME 44.9.
-
-### Example
-
-```
-$ ./vbox-adapter-check.py
-windows10 1: Enabled  HostOnly
-windows10 2: Disabled Null
-windows10 3: Disabled Null
-windows10 4: Disabled Null
-windows10 5: Disabled Null
-windows10 6: Disabled Null
-windows10 7: Disabled Null
-windows10 8: Disabled Null
-FLARE-VM.20240808.dynamic 1: Enabled  NAT
-FLARE-VM.20240808.dynamic 2: Disabled NAT
-FLARE-VM.20240808.dynamic 3: Disabled Bridged
-FLARE-VM.20240808.dynamic 4: Enabled  Internal
-FLARE-VM.20240808.dynamic 5: Disabled Null
-FLARE-VM.20240808.dynamic 6: Disabled Null
-FLARE-VM.20240808.dynamic 7: Disabled Null
-FLARE-VM.20240808.dynamic 8: Disabled Null
-```
-
-#### Notification
-
-![Notification](../Images/vbox-adapter-check_notification.png)
-
 
 ## Clean up snapshots
 
@@ -120,9 +51,80 @@ See you next time you need to clean up your VMs! ✨
 
 ##### Before
 
-
 ![Before](../Images/vbox-clean-snapshots_before.png)
 
 ##### After
 
 ![After](../Images/vbox-clean-snapshots_after.png)
+
+
+## Check internet adapter status
+
+[`vbox-adapter-check.py`](vbox-adapter-check.py) prints the status of all internet adapters of all VMs in VirtualBox.
+The script also notifies if any dynamic analysis VM (with `.dynamic` in the name) has an adapter whose type is not allowed (internet access is undesirable for dynamic malware analysis).
+Unless the argument `--do_not_modify` is provided, the script changes the type of the adapters with non-allowed type to Host-Only.
+Unless the argument `--skip_disabled` is provided, the script also explores the disabled adapters, printing their status and possibly changing their type.
+The script has been tested in Debian 12 with GNOME 44.9.
+
+### Example
+
+```
+$ ./vbox-adapter-check.py
+windows10 1: Enabled  HostOnly
+windows10 2: Disabled Null
+windows10 3: Disabled Null
+windows10 4: Disabled Null
+windows10 5: Disabled Null
+windows10 6: Disabled Null
+windows10 7: Disabled Null
+windows10 8: Disabled Null
+FLARE-VM.20240808.dynamic 1: Enabled  NAT
+FLARE-VM.20240808.dynamic 2: Disabled NAT
+FLARE-VM.20240808.dynamic 3: Disabled Bridged
+FLARE-VM.20240808.dynamic 4: Enabled  Internal
+FLARE-VM.20240808.dynamic 5: Disabled Null
+FLARE-VM.20240808.dynamic 6: Disabled Null
+FLARE-VM.20240808.dynamic 7: Disabled Null
+FLARE-VM.20240808.dynamic 8: Disabled Null
+```
+
+#### Notification
+
+![Notification](../Images/vbox-adapter-check_notification.png)
+
+
+## Export snapshots
+
+[`vbox-export-snapshots.py`](vbox-export-snapshots.py) export one or more snapshots in the same VirtualBox VM as .ova, changing the network to a single Host-Only interface.
+It also generates a file with the SHA256 hash of the exported `.ova`.
+This script is useful to export several versions of FLARE-VM after its installation consistently and with the internet disabled by default (desired for malware analysis).
+For example, you may want to export a VM with the default FLARE-VM configuration and another installing in addition the packages `visualstudio.vm` and `pdbs.pdbresym.vm`.
+These packages are useful for malware analysis but are not included in the default configuration because of the consequent increase in size.
+The scripts receives the path of the JSON configuration file as argument.
+See configuration example files in the [`configs`](configs/) directory.
+
+### Example
+
+```
+$ ./vbox-export-snapshots.py configs/export_win10_flare-vm.json
+
+Exporting snapshots from "FLARE-VM.testing" {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d}
+Export directory: "/home/anamg/EXPORTED VMS"
+
+VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} state: running. Shutting down VM...
+VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ✨ restored snapshot "FLARE-VM"
+VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} state: saved. Starting VM...
+VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} state: running. Shutting down VM...
+VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ⚙️  network set to single hostonly adapter
+VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} 🔄 power cycling before export... (it will take some time, go for an 🍦!)
+VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} state: poweroff. Starting VM...
+VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} state: running. Shutting down VM...
+VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} 🚧 exporting "FLARE-VM.20250129.dynamic"... (it will take some time, go for an 🍦!)
+VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ✅ EXPORTED "/home/anamg/EXPORTED VMS/FLARE-VM.20250129.dynamic.ova"
+VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ✅ GENERATED "/home/anamg/EXPORTED VMS/FLARE-VM.20250129.dynamic.ova.sha256": 73c3de4175449987ef6047f6e0bea91c1036a8599b43113b3f990104ab294a47
+
+VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ❌ ERROR exporting "FLARE-VM.full":Command 'VBoxManage snapshot {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} restore FLARE-VM.full' failed: Could not find a snapshot named 'FLARE-VM.full'
+
+Done! 🙃
+```
+

--- a/virtualbox/vbox-build-vm.py
+++ b/virtualbox/vbox-build-vm.py
@@ -13,27 +13,46 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+"""
+Restore a `BUILD-READY` snapshot, copy files required for the installation (like the IDA Pro installer and
+the FLARE-VM configuration file) and start the FLARE-VM installation.
+"""
 
 import os
 
-import pyperclip
 from vboxcommon import ensure_vm_running, get_vm_uuid, restore_snapshot, run_vboxmanage
 
 VM_NAME = "FLARE-VM.testing"
+# The base snapshot is expected to be an empty Windows installation that satisfies the FLARE-VM installation requirements and has UAC disabled
+# To disable UAC execute in a cmd console with admin rights and restart the VM for the change to take effect:
+# %windir%\System32\reg.exe ADD HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System /v EnableLUA /t REG_DWORD /d 0 /f
 BASE_SNAPSHOT = "BUILD-READY"
 GUEST_USERNAME = "flare"
 GUEST_PASSWORD = "password"
+script_directory = os.path.dirname(os.path.realpath(__file__))
 REQUIRED_FILES_DIR = os.path.expanduser("~/REQUIRED FILES")
-REQUIRED_FILES_DEST = "C:\\Users\\flare\\Desktop"
+REQUIRED_FILES_DEST = f"C:\\Users\\{GUEST_USERNAME}\\Desktop"
 INSTALLATION_COMMAND = r"""
 $desktop=[Environment]::GetFolderPath("Desktop")
 cd $desktop
 Set-ExecutionPolicy Unrestricted -Force
 $url="https://raw.githubusercontent.com/mandiant/flare-vm/main/install.ps1"
-(New-Object net.webclient).DownloadFile($url,"$desktop/install.ps1")
+$file = "$desktop/install.ps1"
+(New-Object net.webclient).DownloadFile($url,$file)
 Unblock-File .\install.ps1
-.\install.ps1 -password password -noWait -noGui -noChecks
+
+start powershell "$file -password password -noWait -noGui -noChecks"
 """
+
+
+def control_guest(vm_uuid, args):
+    """Run a 'VBoxManage guestcontrol' command providing the username and password.
+    Args:
+        vm_uuid: VM UUID
+        args: list of arguments starting with the guestcontrol sub-command
+    """
+    run_vboxmanage(["guestcontrol", vm_uuid, f"--username={GUEST_USERNAME}", f"--password={GUEST_PASSWORD}"] + args)
+
 
 vm_uuid = get_vm_uuid(VM_NAME)
 if not vm_uuid:
@@ -45,23 +64,11 @@ print(f'\nGetting the installation VM "{VM_NAME}" {vm_uuid} ready...\n')
 restore_snapshot(vm_uuid, BASE_SNAPSHOT)
 ensure_vm_running(vm_uuid)
 
-run_vboxmanage(
-    [
-        "guestcontrol",
-        vm_uuid,
-        f"--username={GUEST_USERNAME}",
-        f"--password={GUEST_PASSWORD}",
-        "copyto",
-        "--recursive",
-        f"--target-directory={REQUIRED_FILES_DEST}",
-        REQUIRED_FILES_DIR,
-    ]
-)
-
-print(f"VM {vm_uuid} 📁 Required files copied")
+control_guest(vm_uuid, ["copyto", "--recursive", f"--target-directory={REQUIRED_FILES_DEST}", REQUIRED_FILES_DIR])
+print(f"VM {vm_uuid} 📁 Copied required files in: {REQUIRED_FILES_DIR}")
 
 
-print("\n🎀 READY TO BUILD FLARE-VM")
-input("Press any key to copy installation command...")
-pyperclip.copy(INSTALLATION_COMMAND)
-print("✅ COPIED! Paste the copied installation command in a PowerShell console with admin rights to install FLARE-VM")
+control_guest(vm_uuid, ["run", "C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", INSTALLATION_COMMAND])
+
+print(f"\nVM {vm_uuid} ✅ FLARE-VM is being installed... it will take some time,")
+print("  Go for an 🍦 and enjoy FLARE-VM when you are back!")

--- a/virtualbox/vbox-build-vm.py
+++ b/virtualbox/vbox-build-vm.py
@@ -1,0 +1,67 @@
+#!/usr/bin/python3
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+
+import pyperclip
+from vboxcommon import ensure_vm_running, get_vm_uuid, restore_snapshot, run_vboxmanage
+
+VM_NAME = "FLARE-VM.testing"
+BASE_SNAPSHOT = "BUILD-READY"
+GUEST_USERNAME = "flare"
+GUEST_PASSWORD = "password"
+REQUIRED_FILES_DIR = os.path.expanduser("~/REQUIRED FILES")
+REQUIRED_FILES_DEST = "C:\\Users\\flare\\Desktop"
+INSTALLATION_COMMAND = r"""
+$desktop=[Environment]::GetFolderPath("Desktop")
+cd $desktop
+Set-ExecutionPolicy Unrestricted -Force
+$url="https://raw.githubusercontent.com/mandiant/flare-vm/main/install.ps1"
+(New-Object net.webclient).DownloadFile($url,"$desktop/install.ps1")
+Unblock-File .\install.ps1
+.\install.ps1 -password password -noWait -noGui -noChecks
+"""
+
+vm_uuid = get_vm_uuid(VM_NAME)
+if not vm_uuid:
+    print(f'❌ ERROR: "{VM_NAME}" not found')
+    exit()
+
+print(f'\nGetting the installation VM "{VM_NAME}" {vm_uuid} ready...\n')
+
+restore_snapshot(vm_uuid, BASE_SNAPSHOT)
+ensure_vm_running(vm_uuid)
+
+run_vboxmanage(
+    [
+        "guestcontrol",
+        vm_uuid,
+        f"--username={GUEST_USERNAME}",
+        f"--password={GUEST_PASSWORD}",
+        "copyto",
+        "--recursive",
+        f"--target-directory={REQUIRED_FILES_DEST}",
+        REQUIRED_FILES_DIR,
+    ]
+)
+
+print(f"VM {vm_uuid} 📁 Required files copied")
+
+
+print("\n🎀 READY TO BUILD FLARE-VM")
+input("Press any key to copy installation command...")
+pyperclip.copy(INSTALLATION_COMMAND)
+print("✅ COPIED! Paste the copied installation command in a PowerShell console with admin rights to install FLARE-VM")

--- a/virtualbox/vboxcommon.py
+++ b/virtualbox/vboxcommon.py
@@ -18,9 +18,12 @@ import time
 
 
 def format_arg(arg):
-    """Add quotes to the string arg if it contains spaces."""
-    if " " in arg:
-        return f"'{arg}'"
+    """Add quotes to the string arg if it contains special characters like spaces."""
+    if any(c in arg for c in (" ", "\\", "/")):
+        if "'" not in arg:
+            return f"'{arg}'"
+        if '"' not in arg:
+            return f'"{arg}"'
     return arg
 
 

--- a/virtualbox/vboxcommon.py
+++ b/virtualbox/vboxcommon.py
@@ -78,6 +78,19 @@ def ensure_hostonlyif_exists():
     return hostonlyif_name
 
 
+def get_vm_uuid(vm_name):
+    """Get the machine UUID for a given VM name using 'VBoxManage list vms'. Return None if not found."""
+    # regex VM name and extract the GUID
+    # Example of `VBoxManage list vms` output:
+    # "FLARE-VM.testing" {b76d628b-737f-40a3-9a16-c5f66ad2cfcc}
+    # "FLARE-VM" {a23c0c37-2062-4cf0-882b-9e9747dd33b6}
+    vms_info = run_vboxmanage(["list", "vms"])
+
+    match = re.search(rf'^"{vm_name}" (?P<uuid>\{{.*?\}})', vms_info, flags=re.M)
+    if match:
+        return match.group("uuid")
+
+
 def get_vm_state(vm_uuid):
     """Get the VM state using 'VBoxManage showvminfo'."""
     # Example of `VBoxManage showvminfo <VM_UUID> --machinereadable` relevant output:
@@ -137,3 +150,12 @@ def ensure_vm_shutdown(vm_uuid):
 
     if not wait_until_vm_state(vm_uuid, "poweroff"):
         raise RuntimeError(f"Unable to shutdown VM {vm_uuid}.")
+
+
+def restore_snapshot(vm_uuid, snapshot_name):
+    """Restore a given snapshot in the given VM."""
+    # VM must be shutdown before restoring snapshot
+    ensure_vm_shutdown(vm_uuid)
+
+    run_vboxmanage(["snapshot", vm_uuid, "restore", snapshot_name])
+    print(f'VM {vm_uuid} ✨ restored snapshot "{snapshot_name}"')


### PR DESCRIPTION
Add `virtualbox/vbox-build-flare-vm.py`, a helper script designed to streamline the process of preparing a VirtualBox VM for building FLARE-VM by restoring a pre-configured `BUILD-READY` snapshot and copying necessary files to the VM. After that execute the FLARE-VM installation command in the guest VM. This requires to have previously disabled UAC in the `BUILD-READY` snapshot. The documentation includes instructions on how to do this.

