### PR TITLE
Replaced deprecated wmic cmd in install.ps1

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -332,8 +332,9 @@ if (-not $noChecks.IsPresent) {
     }
 
     Write-Host "[+] Setting password to never expire to avoid that a password expiration blocks the installation..."
-    wmic useraccount here "name='${Env:UserName}'" set PasswordExpires=False
-
+    $UserNoPasswd = Get-CimInstance Win32_UserAccount -Filter "Name='$Env:UserName'"
+    $UserNoPasswd | Set-CimInstance -Property @{ PasswordExpires = $false }
+    
     # Prompt user to remind them to take a snapshot
     Write-Host "[-] Have you taken a VM snapshot to ensure you can revert to pre-installation state? (Y/N): " -ForegroundColor Yellow -NoNewline
     $response = Read-Host


### PR DESCRIPTION
Replaces the deprecated and no longer included "wmic" command with Get-CimInstance.  Verified functionality in a new 24H2 VM installation.

Verification:
Get-CimInstance Win32_UserAccount -Filter "Name='$Env:UserName'" -property PasswordExpires | select-object PasswordExpires

PasswordExpires
---------------
          False