### PR TITLE
[config] Add nmap.vm

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -89,6 +89,7 @@
         <package name="map.vm"/>
         <package name="nasm.vm"/>
         <package name="net-reactor-slayer.vm"/>
+        <package name="nmap.vm"/>
         <package name="notepadplusplus.vm"/>
         <package name="notepadpp.plugin.compare.vm"/>
         <package name="notepadpp.plugin.jstool.vm"/>


### PR DESCRIPTION
Add nmap.vm to the default configuration which installs nmap, ncat, ndiff, and nping.

We removed netcat.vm in favor of nmap.vm (as it includes ncat) in https://github.com/mandiant/flare-vm/pull/633. But it seems we forgot to add nmap.vm to the default configuation. I missed ncat today. :sob: 