### PR TITLE
Add PowerShell linter & minor enhacement in the installer

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -22,4 +22,7 @@ jobs:
         run: flake8 --max-line-length=150
       - name: Run isort
         run: isort --check --diff --profile black --line-length=120 .
+      - name: Run PowerShell linter
+        run: scripts/lint.ps1
+
 

--- a/install.ps1
+++ b/install.ps1
@@ -247,13 +247,13 @@ if (-not $noChecks.IsPresent) {
 
     # Check for spaces in the username, exit if identified
     Write-Host "[+] Checking for spaces in the username..."
-    if (${Env:userName} -match '\s') {
+    if (${Env:UserName} -match '\s') {
         Write-Host "`t[!] Username '${Env:UserName}' contains a space and will break installation." -ForegroundColor Red
         Write-Host "`t[!] Exiting..." -ForegroundColor Red
         Start-Sleep 3
         exit 1
     } else {
-        Write-Host "`t[+] Username '$extractedUsername' does not contain any spaces." -ForegroundColor Green
+        Write-Host "`t[+] Username '${Env:UserName}' does not contain any spaces." -ForegroundColor Green
     }
 
     # Check if host has enough disk space
@@ -333,7 +333,7 @@ if (-not $noChecks.IsPresent) {
     }
 
     Write-Host "[+] Setting password to never expire to avoid that a password expiration blocks the installation..."
-    $UserNoPasswd = Get-CimInstance Win32_UserAccount -Filter "Name='$Env:UserName'"
+    $UserNoPasswd = Get-CimInstance Win32_UserAccount -Filter "Name='${Env:UserName}'"
     $UserNoPasswd | Set-CimInstance -Property @{ PasswordExpires = $false }
 
     # Prompt user to remind them to take a snapshot
@@ -350,10 +350,10 @@ if (-not $noPassword.IsPresent) {
         Write-Host "[+] Getting user credentials ..."
         Set-ItemProperty "HKLM:\SOFTWARE\Microsoft\PowerShell\1\ShellIds" -Name "ConsolePrompting" -Value $True
         Start-Sleep -Milliseconds 500
-        $credentials = Get-Credential ${Env:username}
+        $credentials = Get-Credential ${Env:UserName}
     } else {
         $securePassword = ConvertTo-SecureString -String $password -AsPlainText -Force
-        $credentials = New-Object -TypeName "System.Management.Automation.PSCredential" -ArgumentList ${Env:username}, $securePassword
+        $credentials = New-Object -TypeName "System.Management.Automation.PSCredential" -ArgumentList ${Env:UserName}, $securePassword
     }
 }
 

--- a/install.ps1
+++ b/install.ps1
@@ -139,7 +139,7 @@ function Get-ConfigFile {
         # If the source doesn't exist, assume it's a URL and download the file.
         Write-Host "[+] Downloading config file from '$fileSource'"
         try {
-            (New-Object System.Net.WebClient).DownloadFile($fileSource, $fileDestination)
+            Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://boxstarter.org/bootstrapper.ps1'))
         } catch {
             Write-Host "`t[!] Failed to download '$fileSource'"
             Write-Host "`t[!] $_"
@@ -191,9 +191,10 @@ if (-not $noChecks.IsPresent) {
         Start-Sleep -Milliseconds 500
     }
 
+    $os = Get-CimInstance -Class Win32_OperatingSystem
     # Check if Windows 7
     Write-Host "[+] Checking to make sure Operating System is compatible..."
-    if ((Get-WmiObject -class Win32_OperatingSystem).Version -eq "6.1.7601") {
+    if ($os.Version -eq "6.1.7601") {
         Write-Host "`t[!] Windows 7 is no longer supported / tested" -ForegroundColor Yellow
         Write-Host "[-] Do you still wish to proceed? (Y/N): " -ForegroundColor Yellow -NoNewline
         $response = Read-Host
@@ -203,12 +204,11 @@ if (-not $noChecks.IsPresent) {
     }
 
     # Check if host has been tested
-    $osVersion = (Get-WmiObject -class Win32_OperatingSystem).BuildNumber
     # 17763: the version used by windows-2019 in GH actions
     # 19045: https://www.microsoft.com/en-us/software-download/windows10ISO downloaded on April 25 2023.
     # 20348: the version used by windows-2022 in GH actions
     $testedVersions = @(17763, 19045, 20348)
-    if ($osVersion -notin $testedVersions) {
+    if ($os.BuildNumber -notin $testedVersions) {
         Write-Host "`t[!] Windows version $osVersion has not been tested. Tested versions: $($testedVersions -join ', ')" -ForegroundColor Yellow
         Write-Host "`t[+] You are welcome to continue, but may experience errors downloading or installing packages" -ForegroundColor Yellow
         Write-Host "[-] Do you still wish to proceed? (Y/N): " -ForegroundColor Yellow -NoNewline
@@ -222,7 +222,7 @@ if (-not $noChecks.IsPresent) {
 
     # Check if system is a virtual machine
     $virtualModels = @('VirtualBox', 'VMware', 'Virtual Machine', 'Hyper-V')
-    $computerSystemModel = (Get-WmiObject win32_computersystem).model
+    $computerSystemModel = (Get-CimInstance -Class Win32_ComputerSystem).Model
     $isVirtualModel = $false
 
     foreach ($model in $virtualModels) {
@@ -334,7 +334,7 @@ if (-not $noChecks.IsPresent) {
     Write-Host "[+] Setting password to never expire to avoid that a password expiration blocks the installation..."
     $UserNoPasswd = Get-CimInstance Win32_UserAccount -Filter "Name='$Env:UserName'"
     $UserNoPasswd | Set-CimInstance -Property @{ PasswordExpires = $false }
-    
+
     # Prompt user to remind them to take a snapshot
     Write-Host "[-] Have you taken a VM snapshot to ensure you can revert to pre-installation state? (Y/N): " -ForegroundColor Yellow -NoNewline
     $response = Read-Host
@@ -367,7 +367,7 @@ if (${Env:ChocolateyInstall} -and (Test-Path "${Env:ChocolateyInstall}\bin\choco
 if (-not $boxstarterVersionGood) {
     Write-Host "[+] Installing Boxstarter..." -ForegroundColor Cyan
     [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
-    Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://boxstarter.org/bootstrapper.ps1'))
+    (New-Object System.Net.WebClient).DownloadString('https://boxstarter.org/bootstrapper.ps1') | Out-Null
     Get-Boxstarter -Force
 
     Start-Sleep -Milliseconds 500
@@ -959,13 +959,13 @@ if (-not $noWait.IsPresent) {
     Write-Host @"
 [!] INSTALL NOTES - PLEASE READ CAREFULLY [!]
 
-- This install is not 100% unattended. Please monitor the install for possible failures. If install 
+- This install is not 100% unattended. Please monitor the install for possible failures. If install
 fails, you may restart the install by re-running the install script with the following command:
 
     .\install.ps1 -password <password> -noWait -noGui -noChecks
 
-- You can check which packages failed to install by listing the C:\ProgramData\chocolatey\lib-bad 
-directory. Failed packages are stored by folder name. You may attempt manual installation with the 
+- You can check which packages failed to install by listing the C:\ProgramData\chocolatey\lib-bad
+directory. Failed packages are stored by folder name. You may attempt manual installation with the
 following command:
 
     choco install -y <package_name>

--- a/install.ps1
+++ b/install.ps1
@@ -191,11 +191,12 @@ if (-not $noChecks.IsPresent) {
         Start-Sleep -Milliseconds 500
     }
 
+    # Check if Windows < 10
     $os = Get-CimInstance -Class Win32_OperatingSystem
-    # Check if Windows 7
-    Write-Host "[+] Checking to make sure Operating System is compatible..."
-    if ($os.Version -eq "6.1.7601") {
-        Write-Host "`t[!] Windows 7 is no longer supported / tested" -ForegroundColor Yellow
+    $osMajorVersion = $os.Version.Split('.')[0] # Version examples: "6.1.7601", "10.0.19045"
+    Write-Host "[+] Checking Operating System version compatibility..."
+    if ($osMajorVersion -lt 10) {
+        Write-Host "`t[!] Only Windows >= 10 is supported" -ForegroundColor Yellow
         Write-Host "[-] Do you still wish to proceed? (Y/N): " -ForegroundColor Yellow -NoNewline
         $response = Read-Host
         if ($response -notin @("y","Y")) {

--- a/scripts/lint.ps1
+++ b/scripts/lint.ps1
@@ -1,0 +1,17 @@
+# Exclude rules that make the code less readable or involve changing the functionality
+$excludedRules = "PSAvoidUsingPlainTextForPassword", "PSAvoidUsingConvertToSecureStringWithPlainText", "PSAvoidUsingWriteHost", "PSUseShouldProcessForStateChangingFunctions", "PSUseSingularNouns", "PSAvoidUsingInvokeExpression"
+
+choco install psscriptanalyzer --version 1.23.0 --no-progress
+
+# Manually iterate over all files instead of using -Recurse because
+# PSScriptAnalyzer only outputs the script name (and most have the name
+# chocolateyinstall.ps1)
+$scripts = Get-ChildItem . -Filter *.ps*1 -Recurse -File -Name
+$errorsCount = 0
+foreach ($script in $scripts) {
+  Write-Host -ForegroundColor Yellow $script
+  ($errors = Invoke-ScriptAnalyzer $script -Recurse -ReportSummary -ExcludeRule $excludedRules)
+  $errorsCount += $errors.Count
+}
+
+Exit($errorsCount)


### PR DESCRIPTION
- Add PowerShell linter similar to the [linter in VM-Packages](https://github.com/mandiant/VM-Packages/blob/main/scripts/test/lint.ps1). Fix offenses detected by the linter manually, including replacing the WMI cmdlet by the CIM cmdlet. Closes https://github.com/mandiant/flare-vm/issues/507.
- Check that Windows is >= 10 instead of only checking `6.1.7601`.
- Add missing user name to info message and write the environment variable name always in the same way. This issue was introduced when I simplified the code to get the user name in https://github.com/mandiant/flare-vm/commit/cc103449a543cc7452bbb2aa8612549eed240595.

