### PR TITLE
[config] Remove libraries-extra.python3.vm

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -82,7 +82,6 @@
         <package name="isd.vm"/>
         <package name="js-beautify.vm"/>
         <package name="js-deobfuscator.vm"/>
-        <package name="libraries-extra.python3.vm"/>
         <package name="libraries.python3.vm"/>
         <package name="magika.vm"/>
         <package name="malware-jail.vm"/>


### PR DESCRIPTION
libraries-extra.python3.vm used to install the XRefer dependencies and was removed with the introduction of the ida.plugin.xrefer.vm package in https://github.com/mandiant/VM-Packages/pull/1207

We already have ida.plugin.xrefer.vm in the default configuration, so libraries-extra.python3.vm is not needed. libraries-extra.python3.vm will be removed from MyGet soon (see https://github.com/mandiant/VM-Packages/issues/1326), not being available anymore.