### PR TITLE
[vbox-clean-snapshots] Improve protected snapshots

### DIFF
--- a/virtualbox/README.md
+++ b/virtualbox/README.md
@@ -14,6 +14,10 @@ It is not possible to select and delete several snapshots in VirtualBox, making 
 ```
 $ ./vbox-remove-snapshots.py FLARE-VM.20240604
 
+Snapshots with the following strings in the name (case insensitive) won't be deleted:
+  clean
+  done
+
 Cleaning FLARE-VM.20240604 🫧 Snapshots to delete:
   Snapshot 1
   wip unpacked

--- a/virtualbox/vbox-clean-snapshots.py
+++ b/virtualbox/vbox-clean-snapshots.py
@@ -103,6 +103,11 @@ def get_snapshot_children(vm_name, root_snapshot_name, protected_snapshots):
 def delete_snapshot_and_children(vm_name, snapshot_name, protected_snapshots):
     snaps_to_delete = get_snapshot_children(vm_name, snapshot_name, protected_snapshots)
 
+    if protected_snapshots:
+        print("\nSnapshots with the following strings in the name (case insensitive) won't be deleted:")
+        for protected_snapshot in protected_snapshots:
+            print(f"  {protected_snapshot}")
+
     if snaps_to_delete:
         print(f"\nCleaning {vm_name} 🫧 Snapshots to delete:")
         for snapshot_name, _ in snaps_to_delete:

--- a/virtualbox/vbox-clean-snapshots.py
+++ b/virtualbox/vbox-clean-snapshots.py
@@ -150,7 +150,7 @@ def main(argv=None):
     parser.add_argument(
         "--protected_snapshots",
         default="clean,done",
-        type=lambda s: s.split(","),
+        type=lambda s: s.split(",") if s else [],
         help='''Comma-separated list of strings.
                 Snapshots with any of the strings included in the name (case insensitive) are not deleted.
                 Default: "clean,done"''',


### PR DESCRIPTION
This PR enhance the following in the `vbox-clean-snapshots.py` script:
- if `protected_snapshots` argument is an empty string, no snapshots should be excluded. Instead all snapshots were excluded. Handle this case explicitly fixing the bug.
- Print protected snapshots, so that the user is aware that they won't be deleted.