### PR TITLE
Minor bug fixes in vbox-build-flare-vm.py

### DIFF
--- a/virtualbox/configs/win10_flare-vm.yaml
+++ b/virtualbox/configs/win10_flare-vm.yaml
@@ -12,10 +12,13 @@ SNAPSHOTS:
 - extension: ".EDU"
   description: "Windows 10 VM with FLARE-VM default configuration + FLARE-EDU materials"
   cmd: |
+    $desktop = "C:\Users\flare\Desktop";
+    Set-Location $desktop
+
     # Unzip EDU labs
     VM-Unzip-Recursively;
+
     # Install Office 2016. the installation takes 30 minutes
-    $desktop = "C:\Users\flare\Desktop";
     $path = "$desktop\en_office_professional_plus_2016_x86_x64_dvd_6962141.iso";
     $drive = (Mount-DiskImage -ImagePath $path | Get-Volume).DriveLetter;
     Set-Location "$drive`:\";

--- a/virtualbox/vbox-build-flare-vm.py
+++ b/virtualbox/vbox-build-flare-vm.py
@@ -270,7 +270,7 @@ def main(argv=None):
     parser.add_argument("config_path", help="path of the YAML configuration file.")
     parser.add_argument(
         "--date",
-        help="Date to include in the snapshots and the exported VMs in YYMMDD format. Today's date by default.",
+        help="Date to include in the snapshots and the exported VMs in YYYYMMDD format. Today's date by default.",
         default=datetime.today().strftime("%Y%m%d"),
     )
     parser.add_argument(


### PR DESCRIPTION
Correct the fix date format in the help message of `vbox-build-flare-vm.py`.

In the EDU VM configuration, run `VM-Unzip-Recursively`  from the Desktop as it otherwise fails because of the following bug: https://github.com/mandiant/VM-Packages/issues/1388