### PR TITLE
Automate customized REMnux builds

### DIFF
--- a/virtualbox/README.md
+++ b/virtualbox/README.md
@@ -5,7 +5,7 @@
 
 ## Clean up snapshots
 
-It is not possible to select and delete several snapshots in VirtualBox, making cleaning up your VM manually after having creating a lot snapshots time consuming and tedious (possible errors when deleting several snapshots simultaneously).
+It is not possible to select and delete several snapshots in VirtualBox, making cleaning up your virtual machine (VM) manually after having creating a lot snapshots time consuming and tedious (possible errors when deleting several snapshots simultaneously).
 
 [`vbox-clean-snapshots.py`](vbox-clean-snapshots.py) cleans a VirtualBox VM up by deleting a snapshot and its children recursively skipping snapshots with a substring in the name.
 
@@ -123,16 +123,16 @@ VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ✅ EXPORTED "/home/anamg/None/FLARE-V
 VM {2bc66f50-9ecb-4b10-a4dd-0cc329bc383d} ✅ GENERATED "/home/anamg/None/FLARE-VM.ova.sha256": 987eed68038ce7c5072e7dc219ba82d11745267d8ab2ea7f76158877c13e3aa9
 ```
 
-## Build FLARE-VM
+## Build FLARE-VM VM(s)
 
-[`vbox-build-flare-vm.py`](vbox-build-flare-vm.py) automates the creation and export of customized FLARE-VM virtual machines (VMs).
+[`vbox-build-flare-vm.py`](vbox-build-flare-vm.py) automates the creation and export of customized FLARE-VM VMs.
 The script begins by restoring a pre-existing `BUILD-READY` snapshot of a clean Windows installation.
 The script then copies the required installation files (such as the IDA Pro installer, FLARE-VM configuration, and legal notices) into the guest VM.
 After installing FLARE-VM, a `base` snapshot is taken.
 This snapshot serves as the foundation for generating subsequent snapshots and exporting OVA images, all based on the configuration provided in a YAML file.
 This configuration file specifies the VM name, the exported VM name, and details for each snapshot.
 Individual snapshot configurations can include custom commands to be executed within the guest, legal notices to be applied, and file/folder exclusions for the automated cleanup process.
-See configuration example files in the [`configs`](configs/) directory.
+See the configuration example file [`configs/win10_flare-vm.yaml`](configs/win10_flare-vm.yaml).
 
 The `BUILD-READY` snapshot is expected to be an empty Windows installation that satisfies the FLARE-VM installation requirements and has UAC disabled
 To disable UAC execute in a cmd console with admin rights and restart the VM for the change to take effect:
@@ -140,3 +140,11 @@ To disable UAC execute in a cmd console with admin rights and restart the VM for
 %windir%\System32\reg.exe ADD HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Policies\System /v EnableLUA /t REG_DWORD /d 0 /f
 ```
 
+## Build REMnux VM
+
+Similarly to [`vbox-build-flare-vm.py`](vbox-build-flare-vm.py), [`vbox-build-remnux.py`](vbox-build-remnux.py) automates the creation and export of customized REMnux virtual machines (VMs).
+The script begins by restoring a pre-existing "BUILD-READY" snapshot of a clean REMnux OVA.
+Required installation files (such as the IDA Pro installer and ZIPs with GNOME extensions) are then copied into the guest VM.
+The configuration file specifies the VM name, the exported VM name, and details for each snapshot.
+Individual snapshot configurations include the extension, description, and custom commands to be executed within the guest.
+See the configuration example file [`configs/remnux.yaml`](configs/remnux.yaml).

--- a/virtualbox/configs/remnux.yaml
+++ b/virtualbox/configs/remnux.yaml
@@ -1,0 +1,54 @@
+VM_NAME: REMnux.testing
+EXPORTED_VM_NAME: REMnux
+SNAPSHOT:
+  extension: ".dynamic"
+  description: "REMnux (based on Ubuntu) with improved configuration"
+CMDS:
+  - |
+    # Install additional useful packages
+    sudo apt-get --assume-yes install libwrap0-dev gdb-multiarch qemu gcc-multilib libcurl4:i386
+
+  - |
+    # Uninstall distro-info to fix "Invalid version: '0.23ubuntu1'" Python install warning
+    # Uninstall it in both the default and Python 3.9
+    sudo pip uninstall -y distro-info
+    sudo /usr/bin/python3.9 -m pip uninstall -y distro-info
+
+  - |
+    # Install additional Python libraries
+    pip install -U pip
+    pip install rpyc flare-capa lznt1
+
+  - |
+    # Install additional Python libraries using Python 3.9
+    /usr/bin/python3.9 -m pip install -U pip
+    /usr/bin/python3.9 -m pip install rpyc flare-capa lznt1
+
+  - |
+    # Install IDA
+    # Expected IDA 9 installer in the Desktop
+    cd /home/remnux/Desktop
+    sudo chmod +x ida-pro_*.run
+    ./ida-pro_*.run --mode unattended
+
+    # Add IDA to favourite apps on startup (/usr/local/share/remnux/gnome-config.sh replaces it on startup)
+    ida_app=$(basename /home/remnux/.local/share/applications/com.hex_rays.IDA.pro*.desktop)
+    favourite_apps=$(gsettings get org.gnome.shell favorite-apps | sed 's/.$//')
+    echo '' | sudo tee -a /usr/local/share/remnux/gnome-config.sh
+    echo "gsettings set org.gnome.shell favorite-apps \"$favourite_apps, '$ida_app']\"" | sudo tee -a /usr/local/share/remnux/gnome-config.sh
+
+    # Ensure files are written to persistent storage as the script shut down the VM abruptly
+    sync
+
+  - |
+    # Install Dash to Panel extension
+    # Expected a ZIP with a version for the GNOME shell 3.36 in the Desktop
+    cd /home/remnux/Desktop
+    gnome-extensions install dash-to-panel*.shell-extension.zip --force
+
+    # Enable Dash to Panel extension on startup as logout is needed after install
+    echo gnome-extensions enable dash-to-panel@jderose9.github.com | sudo tee -a /usr/local/share/remnux/gnome-config.sh
+
+    # Ensure files are written to persistent storage as the script shut down the VM abruptly
+    sync
+

--- a/virtualbox/vbox-build-remnux.py
+++ b/virtualbox/vbox-build-remnux.py
@@ -1,0 +1,179 @@
+#!/usr/bin/python3
+# Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import sys
+from datetime import datetime
+
+import yaml
+from vboxcommon import (
+    control_guest,
+    ensure_vm_running,
+    export_vm,
+    get_vm_uuid,
+    restore_snapshot,
+    set_network_to_hostonly,
+    take_snapshot,
+)
+
+DESCRIPTION = """
+Automates the creation and export of customized REMnux virtual machines (VMs).
+Begins by restoring a pre-existing "BUILD-READY" snapshot of a clean REMnux OVA.
+Required installation files (such as the IDA Pro installer and ZIPs with GNOME extensions) are then copied into the guest VM.
+The configuration file specifies the VM name, the exported VM name, and details for each snapshot.
+Individual snapshot configurations include the extension, description, and custom commands to be executed within the guest.
+"""
+
+EPILOG = """
+Example usage:
+  #./vbox-build-remnux.py configs/remnux.yaml --date='19930906'
+"""
+
+BASE_SNAPSHOT = "BUILD-READY"
+
+# Guest username and password, needed to execute commands in the guest
+GUEST_USERNAME = "remnux"
+GUEST_PASSWORD = "malware"
+
+# Required files
+REQUIRED_FILES_DIR = os.path.expanduser("~/REMNUX REQUIRED FILES")
+REQUIRED_FILES_DEST = rf"/home/{GUEST_USERNAME}/Desktop"
+
+
+def run_command(vm_uuid, cmd):
+    """Run a command in the guest of the specified VM, displaying the output in real time to the console.
+
+    Args:
+        vm_uuid: VM UUID
+        cmd: The command string to execute in the guest using `/bin/sh -c`.
+    """
+    ensure_vm_running(vm_uuid)
+
+    executable = "/bin/sh"
+    print(f"VM {vm_uuid} 🚧 {executable}: {cmd}")
+    control_guest(vm_uuid, GUEST_USERNAME, GUEST_PASSWORD, ["run", executable, "--", "-c", cmd], True)
+
+
+def build_vm(vm_name, exported_vm_name, snapshot, cmds, date, do_not_upgrade):
+    """
+    Build a REMnux VM and export it as OVA.
+
+    Build a REMnux VM by restoring the BASE_SNAPSHOT, upgrading the REMnux distro,
+    copying required files, running given commands, removing copied required files.
+    Take several snapshots that can be used for debugging issues.
+    Set the network to hostonly and export the resulting VM as OVA.
+
+    Args:
+        vm_name: The name of the VM.
+        exported_vm_name: The base name to use for the final exported VM and snapshots.
+        snapshot: A dictionary containing information about the final snapshot,
+                  including optional `extension` and `description`.
+        cmds: A list of string commands to execute sequentially within the guest VM.
+              A snapshot is taken after executing each command.
+        date: A date string to incorporate into snapshot names and the exported OVA.
+        do_not_upgrade: If True, the initial upgrade step is skipped and an existent UPGRADED snapshot used.
+                        It also does not copy the required files.
+    """
+    vm_uuid = get_vm_uuid(vm_name)
+    if not vm_uuid:
+        print(f'❌ ERROR: "{vm_name}" not found')
+        exit()
+
+    print(f'\nGetting the installation VM "{vm_name}" {vm_uuid} ready...')
+
+    base_snapshot_name = f"UPGRADED.{date}"
+
+    if not do_not_upgrade:
+        restore_snapshot(vm_uuid, BASE_SNAPSHOT)
+
+        # Copy required files
+        control_guest(
+            vm_uuid,
+            GUEST_USERNAME,
+            GUEST_PASSWORD,
+            ["copyto", "--recursive", f"--target-directory={REQUIRED_FILES_DEST}", REQUIRED_FILES_DIR],
+        )
+        print(f"VM {vm_uuid} 📁 Copied required files in: {REQUIRED_FILES_DIR}")
+
+        # Update REMnux distro and take a snapshot
+        run_command(vm_uuid, "sudo remnux upgrade")
+        take_snapshot(vm_uuid, base_snapshot_name)
+    else:
+        restore_snapshot(vm_uuid, base_snapshot_name)
+
+    # Run snapshot configured commands taking a snapshot after running every command
+    for i, cmd in enumerate(cmds):
+        run_command(vm_uuid, cmd)
+        take_snapshot(vm_uuid, f"{exported_vm_name}.{date} CMD {cmd.splitlines()[0]}")
+
+    # Delete required files copied to the VM
+    files = f"{REQUIRED_FILES_DEST}/*"
+    # Sync is needed ti ensure the files deletion is written to persistent storage as the script shut down the VM abruptly
+    run_command(vm_uuid, f"ls {files}; rm {files}; sync")
+
+    set_network_to_hostonly(vm_uuid)
+
+    # Take snapshot turning the VM off
+    extension = snapshot.get("extension", "")
+    snapshot_name = f"{exported_vm_name}.{date}{extension}"
+    take_snapshot(vm_uuid, snapshot_name, True)
+
+    # Export the snapshot with the configured description
+    export_vm(vm_uuid, snapshot_name, snapshot.get("description", ""))
+
+
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+
+    parser = argparse.ArgumentParser(
+        description=DESCRIPTION,
+        epilog=EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("config_path", help="path of the YAML configuration file.")
+    parser.add_argument(
+        "--date",
+        help="Date to include in the snapshots and the exported VMs in YYYYMMDD format. Today's date by default.",
+        default=datetime.today().strftime("%Y%m%d"),
+    )
+    parser.add_argument(
+        "--do-not-upgrade",
+        action="store_true",
+        default=False,
+        help="flag to not upgrade the REMnux distro and use an existent UPGRADED snapshot. It also does not copy the required files.",
+    )
+    args = parser.parse_args(args=argv)
+
+    try:
+        with open(args.config_path) as f:
+            config = yaml.safe_load(f)
+    except Exception as e:
+        print(f'Invalid "{args.config_path}": {e}')
+        exit()
+
+    build_vm(
+        config["VM_NAME"],
+        config["EXPORTED_VM_NAME"],
+        config["SNAPSHOT"],
+        config["CMDS"],
+        args.date,
+        args.do_not_upgrade,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/virtualbox/vboxcommon.py
+++ b/virtualbox/vboxcommon.py
@@ -299,9 +299,9 @@ def ensure_vm_shutdown(vm_uuid):
     if vm_state == "poweroff":
         return
 
-    # If the state is aborted-saved, the VM is not running and can't be turned off
+    # If the state is aborted, the VM is not running and can't be turned off
     # Log the state and return
-    if vm_state == "aborted-saved":
+    if vm_state in ("aborted-saved", "aborted"):
         print(f"VM {vm_uuid} state: {vm_state}")
         return
 

--- a/virtualbox/vboxcommon.py
+++ b/virtualbox/vboxcommon.py
@@ -90,6 +90,25 @@ def run_vboxmanage(cmd, real_time=False):
     return result.stdout
 
 
+def control_guest(vm_uuid, user, password, args, real_time=False):
+    """Run a 'VBoxManage guestcontrol' command providing the username and password.
+    Args:
+        vm_uuid: VM UUID
+        args: list of arguments starting with the guestcontrol sub-command
+        real_time: Boolean that determines if displaying the output in realtime or returning it.
+    """
+    # VM must be running to control the guest
+    ensure_vm_running(vm_uuid)
+    cmd = ["guestcontrol", vm_uuid, f"--username={user}", f"--password={password}"] + args
+    try:
+        return run_vboxmanage(cmd, real_time)
+    except RuntimeError:
+        # The guest additions take a bit to load after the user is logged in
+        # In slow environments this may cause the command to fail, wait a bit and re-try
+        time.sleep(120)  # Wait 2 minutes
+        return run_vboxmanage(cmd, real_time)
+
+
 def get_hostonlyif_name():
     """Get the name of the host-only interface. Return None if there is no host-only interface"""
     # Example of `VBoxManage list hostonlyifs` relevant output:
@@ -304,3 +323,43 @@ def restore_snapshot(vm_uuid, snapshot_name):
 
     run_vboxmanage(["snapshot", vm_uuid, "restore", snapshot_name])
     print(f'VM {vm_uuid} ✨ restored snapshot "{snapshot_name}"')
+
+
+def rename_old_snapshot(vm_uuid, snapshot_name):
+    """Append 'OLD' to the name of all snapshots with the given name within the specified VM.
+
+    Args:
+        vm_uuid: VM UUID
+        snapshot_name: The current name of the snapshot(s) to rename.
+    """
+    # Example of 'VBoxManage snapshot VM_NAME list --machinereadable' output:
+    # SnapshotName="ROOT"
+    # SnapshotUUID="86b38fc9-9d68-4e4b-a033-4075002ab570"
+    # SnapshotName-1="Snapshot 1"
+    # SnapshotUUID-1="e383e702-fee3-4e0b-b1e0-f3b869dbcaea"
+    snapshots_info = run_vboxmanage(["snapshot", vm_uuid, "list", "--machinereadable"])
+
+    # Find how many snapshots have the given name and edit a snapshot with that name as many times
+    snapshots = re.findall(rf'^SnapshotName(-\d+)*="{snapshot_name}"\n', snapshots_info, flags=re.M)
+    for _ in range(len(snapshots)):
+        run_vboxmanage(["snapshot", vm_uuid, "edit", snapshot_name, f"--name='{snapshot_name} OLD"])
+
+
+def take_snapshot(vm_uuid, snapshot_name, shutdown=False, rename=False):
+    """Take a snapshot of the specified VM with the given name, optionally shutting down first and renaming duplicates.
+
+    Args:
+        vm_uuid: VM UUID
+        snapshot_name: The name for the new snapshot.
+        shutdown: If True, shut down the VM before taking the snapshot.
+        rename: If True, renames any existing snapshots with the same `snapshot_name`
+                by appending ' OLD' to their names before taking the new snapshot.
+    """
+    if shutdown:
+        ensure_vm_shutdown(vm_uuid)
+
+    if rename:
+        rename_old_snapshot(vm_uuid, snapshot_name)
+
+    run_vboxmanage(["snapshot", vm_uuid, "take", snapshot_name])
+    print(f'VM {vm_uuid} 📷 took snapshot "{snapshot_name}"')


### PR DESCRIPTION
Introduce a new script, `vbox-build-remnux.py`, to automate the building and exporting of customized REMnux virtual machines. The script utilizes a YAML configuration file (`remnux.yaml`) to define the VM name, export settings, and a series of commands to execute within the guest VM.

The code and logic are similar to the existing `vbox-build-flare-vm.py`, ensuring consistency between the two build processes. To avoid code duplication, several common functions, such as `control_guest`, `take_snapshot`, and `rename_old_snapshot`, have been moved to the `vboxcommon.py` module.

The REMnux build process includes:
- Restoring a base snapshot.
- Optionally upgrading the REMnux distribution and copying required files into the guest.
- Executing a series of commands defined in the `remnux.yaml` configuration. These commands can include installing additional packages, configuring the environment, and installing tools like IDA Pro and GNOME extensions (e.g., Dash to Panel).
- Taking multiple snapshots throughout the build process for potential debugging.
- Setting the network adapter to host-only.
- Taking a final snapshot with a configurable extension and description.
- Exporting the final snapshot as an OVA file.

Also fix a bug I encountered during testing becase the `aborted` VM state was not properly handled in the shutdown check.