### PR TITLE
[install.ps1] Fix: Add System.Drawing assembly

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -474,6 +474,7 @@ if (-not $noGui.IsPresent) {
     ## BEGIN GUI
     ################################################################################
     Add-Type -AssemblyName System.Windows.Forms
+    Add-Type -Assembly System.Drawing
 
 
     function Get-Folder($textBox, $envVar) {


### PR DESCRIPTION
The `install.ps1` script previously failed in **certain environments** because it couldn't find the `System.Drawing.ColorTranslator` type, as the `System.Drawing` assembly was not loaded. This commit resolves the issue by adding `Add-Type -Assembly System.Drawing`, ensuring the necessary assembly is available.

Closes https://github.com/mandiant/flare-vm/issues/701

As the script worked for me before, @dougsec, @coryfancypants can you please confirm this fixes the issue?