### PR TITLE
[vbox, config] Decouple FLARE-EDU

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -91,6 +91,7 @@
         <package name="magika.vm"/>
         <package name="malware-jail.vm"/>
         <package name="map.vm"/>
+        <package name="microsoft-office.vm"/>
         <package name="nasm.vm"/>
         <package name="net-reactor-slayer.vm"/>
         <package name="nmap.vm"/>

--- a/virtualbox/configs/win10_flare-vm-edu.yaml
+++ b/virtualbox/configs/win10_flare-vm-edu.yaml
@@ -1,0 +1,22 @@
+VM_NAME: FLARE-VM.testing
+EXPORTED_VM_NAME: FLARE-VM.Win10
+SNAPSHOTS:
+- extension: ".EDU"
+  description: "Windows 10 VM with FLARE-VM default configuration + FLARE-EDU materials"
+  cmd: |
+    $desktop = "C:\Users\flare\Desktop";
+    Set-Location $desktop
+
+    # Unzip EDU labs
+    VM-Unzip-Recursively;
+
+    # Install Office 2016. the installation takes 30 minutes
+    $path = "$desktop\en_office_professional_plus_2016_x86_x64_dvd_6962141.iso";
+    $drive = (Mount-DiskImage -ImagePath $path | Get-Volume).DriveLetter;
+    Set-Location "$drive`:\";
+    .\setup.exe;
+    Start-Sleep 1800;
+    Dismount-DiskImage -ImagePath $path;
+  legal_notice: "legal_notice_edu.txt"
+  protected_folders: "'ATMA', 'MACC', 'MAF', 'MDA'"
+  protected_files: "'Labs.zip', 'MICROSOFT Windows 10 License Terms.txt', 'MICROSOFT Office 2016 License Terms.txt'"

--- a/virtualbox/configs/win10_flare-vm.yaml
+++ b/virtualbox/configs/win10_flare-vm.yaml
@@ -2,29 +2,10 @@ VM_NAME: FLARE-VM.testing
 EXPORTED_VM_NAME: FLARE-VM.Win10
 SNAPSHOTS:
 - extension: ".dynamic"
-  description: "Windows 10 VM with FLARE-VM default configuration + idapro.vm + microsoft-office.vm"
-  cmd: "choco install idapro.vm microsoft-office.vm"
+  description: "Windows 10 VM with FLARE-VM default configuration + idapro.vm"
+  cmd: "choco install idapro.vm"
   legal_notice: "legal_notice_win10.txt"
 - extension: ".full.dynamic"
-  description: "Windows 10 VM with FLARE-VM default configuration + idapro.vm + microsoft-office.vm + pdbs.pdbresym.vm + visualstudio.vm"
-  cmd: "choco install idapro.vm microsoft-office.vm pdbs.pdbresym.vm visualstudio.vm --execution-timeout 10000"
+  description: "Windows 10 VM with FLARE-VM default configuration + idapro.vm + pdbs.pdbresym.vm + visualstudio.vm"
+  cmd: "choco install idapro.vm pdbs.pdbresym.vm visualstudio.vm --execution-timeout 10000"
   legal_notice: "legal_notice_win10.txt"
-- extension: ".EDU"
-  description: "Windows 10 VM with FLARE-VM default configuration + FLARE-EDU materials"
-  cmd: |
-    $desktop = "C:\Users\flare\Desktop";
-    Set-Location $desktop
-
-    # Unzip EDU labs
-    VM-Unzip-Recursively;
-
-    # Install Office 2016. the installation takes 30 minutes
-    $path = "$desktop\en_office_professional_plus_2016_x86_x64_dvd_6962141.iso";
-    $drive = (Mount-DiskImage -ImagePath $path | Get-Volume).DriveLetter;
-    Set-Location "$drive`:\";
-    .\setup.exe;
-    Start-Sleep 1800;
-    Dismount-DiskImage -ImagePath $path;
-  legal_notice: "legal_notice_edu.txt"
-  protected_folders: "'ATMA', 'MACC', 'MAF', 'MDA'"
-  protected_files: "'Labs.zip', 'MICROSOFT Windows 10 License Terms.txt', 'MICROSOFT Office 2016 License Terms.txt'"


### PR DESCRIPTION
Separate the build process for the FLARE-EDU VM by removing the specialized .EDU snapshot configuration from the `win10_flare-vm.yaml` file and moving it to `virtualbox/configs/win10_flare-vm-edu.yaml`.

Add `microsoft-office.vm` to the default configuration, as it is an useful analysis tool and simplifies `win10_flare-vm.yaml`. With this new configuration, `win10_flare-vm.yaml` needs to used a custom config if the installation of `microsoft-office.vm` is not desired.