### PR TITLE
Remove dnscache change from config to fix Win11 internet

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -206,7 +206,6 @@
         <registry-item name="Add ZoomIt to Windows Start" path="HKCU:\SOFTWARE\Microsoft\Windows\CurrentVersion\run" value="ZoomIt" type="String" data="C:\Tools\sysinternals\ZoomIt64.exe" />
         <registry-item name="Don't display ZoomIt GUI on login" path="HKCU:\Software\Sysinternals\ZoomIt" value="OptionsShown" type="DWord" data="1" />
         <registry-item name="Hide the .lnk extension" path="HKLM:\SOFTWARE\Classes\lnkfile" value="NeverShowExt" type="String" data=" "/>
-        <registry-item name="Force DNS requests to always come from requesting process" path="HKLM:\SYSTEM\CurrentControlSet\services\Dnscache" value="Start" type="DWord" data="4" />
         <!-- Set dark mode
         <registry-item name="Set Dark Mode on System" path="HKCU:\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize" value="SystemUsesLightTheme" type="DWord" data="0"/>
         <registry-item name="Set Dark Mode on Apps" path="HKCU:\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize" value="AppsUseLightTheme" type="DWord" data="0"/>


### PR DESCRIPTION
This works in tandem with https://github.com/mandiant/VM-Packages/pull/1463 to fix the issue of Windows 11 internet not working due to a modification of the DNS cache value in the registry that we made to make internet requests clearer on Windows 10.

This commit will remove the previous change so that we can put the change into the `win10.xml` config for `debloat.vm` so that the change only effects Windows 10.

See https://github.com/mandiant/flare-vm/issues/659 for more details.