### PR TITLE
[configs/remnux.yaml] Add useful libraries & fakenet fix

### DIFF
--- a/virtualbox/configs/remnux.yaml
+++ b/virtualbox/configs/remnux.yaml
@@ -6,7 +6,8 @@ SNAPSHOT:
 CMDS:
   - |
     # Install additional useful packages
-    sudo apt-get --assume-yes install libwrap0-dev gdb-multiarch qemu gcc-multilib libcurl4:i386
+    sudo apt-get --assume-yes install libwrap0-dev gdb-multiarch qemu gcc-multilib libcurl4:i386 qemu-user libc6-mips64-mips-cross libc6-mipsel-cross libc6-arm64-cross libc6-armel-cross libc6-armhf-cross libc6-ppc64-cross libc6-powerpc-cross
+
 
   - |
     # Uninstall distro-info to fix "Invalid version: '0.23ubuntu1'" Python install warning

--- a/virtualbox/configs/remnux.yaml
+++ b/virtualbox/configs/remnux.yaml
@@ -26,6 +26,11 @@ CMDS:
     /usr/bin/python3.9 -m pip install rpyc flare-capa lznt1
 
   - |
+    # Fix fakenet issue: https://github.com/mandiant/flare-fakenet-ng/tree/master?tab=readme-ov-file#dns-not-resolving-names
+    sudo systemctl stop systemd-resolved
+    sudo systemctl disable systemd-resolved
+
+  - |
     # Install IDA
     # Expected IDA 9 installer in the Desktop
     cd /home/remnux/Desktop


### PR DESCRIPTION
Add useful libraries to REMnux build config.

fakenet fails with the following error:
```
FakeNet] Error starting DNSListener listener on port 53:
FakeNet]  [Errno 98] Address already in use
```

Disable `systemd-resolved` to solve the issue as documented in:
https://github.com/mandiant/flare-fakenet-ng/tree/master?tab=readme-ov-file#dns-not-resolving-names