### PR TITLE
[CI] Add workflow to release vbox executables

### DIFF
--- a/.github/workflows/build-vbox.yaml
+++ b/.github/workflows/build-vbox.yaml
@@ -1,0 +1,49 @@
+name: Build & release vbox
+# Create or update a release by adding a body and the built vbox binaries on a tag creation that starts by `vbox-`.
+# The tag can be created in the GH UI (by creating a release) or using git, e.g.:
+# VERSION=1.0.0 && git tag -a vbox-$VERSION origin/main -m "vbox tag" && git push origin vbox-$VERSION
+
+on:
+  push:
+    tags:
+      - 'vbox-*'
+  workflow_dispatch: # manual trigger for testing
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    # use old linux for better portability
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - name: Install build requirements
+        run: python -m pip install --upgrade pip setuptools pyinstaller pgi
+      - name: Build standalone executables
+        run: |
+          cd virtualbox
+
+          pyinstaller --onefile --log-level DEBUG vbox-adapter-check.py
+          pyinstaller --onefile --log-level DEBUG vbox-clean-snapshots.py
+
+          ls dist
+      # Only test vbox-clean-snapshots as vbox-adapter-check uses Notify and it fails in GH actions
+      - name: Check  vbox-clean-snapshots runs correctly
+        run: virtualbox/dist/vbox-clean-snapshots --help
+      - name: Zip binaries
+        run: zip -rj vbox.zip virtualbox/dist
+      - name: Upload ZIP to release
+        uses: svenstaro/upload-release-action@81c65b7cd4de9b2570615ce3aad67a41de5b1a13 # v2.11.2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: vbox.zip
+          tag: ${{ github.ref }}
+          overwrite: true
+          body: |
+            **FLARE-VM does not have releases**, as the project relies on external URLs outside of our control, making it impossible to install an older version. This release only includes standalone Linux executables for some of the scripts in the [`virtualbox`](https://github.com/mandiant/flare-vm/tree/main/virtualbox) folder (related to use FLARE-VM in VirtualBox) to make them easier to use. **To install FLARE-VM check the instructions in the [FLARE-VM README](https://github.com/mandiant/flare-vm)**.
+
+            - **vbox-adapter-check**: Print the status of all internet adapters of all VMs in VirtualBox. Useful to detect internet access, which is undesirable for dynamic malware analysis. Compatibility is limited to Linux systems using the GTK graphical toolkit, which includes desktops like GNOME.
+            - **vbox-clean-snapshots**: Delete a snapshot and its children recursively skipping snapshots with a substring in the name. Useful to delete several snapshots, which is not possible via the VirtualBox UI.
+


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow (`build-vbox.yaml`) to automate the building and releasing of the VirtualBox helper scripts.

The workflow triggers automatically when a new tag prefixed with `vbox-` is pushed, and can also be triggered manually for testing. It builds standalone Linux executables for `vbox-adapter-check.py` and `vbox-clean-snapshots.py` using PyInstaller. As `vbox-adapter-check.py` uses GObject Introspection, the `vbox-adapter-check` executable is only compatible with Linux desktop environments using the GTK toolkit, such as GNOME.  The generated binaries are then bundled into a `vbox.zip` archive and attached to the corresponding GitHub release. An explanatory message is included in the release body to prevent FLARE-VM users from confusing these script releases with main FLARE-VM project releases.