### PR TITLE
[CI] vboxcommon: Clean environment for subprocess

### DIFF
--- a/.github/workflows/build-vbox.yaml
+++ b/.github/workflows/build-vbox.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install build requirements
-        run: python -m pip install --upgrade pip setuptools pyinstaller pgi
+        run: python -m pip install --upgrade pip pyinstaller
       - name: Build standalone executables
         run: |
           cd virtualbox


### PR DESCRIPTION
When running as a PyInstaller bundle, the bootloader sets the `LD_LIBRARY_PATH` environment variable to point to its temporary directory. This can force `VBoxManage` to use the wrong libraries, causing it to fail.

This change creates a clean environment for the `VBoxManage` subprocess. It restores the original `LD_LIBRARY_PATH` (if available) or removes it, ensuring `VBoxManage` can find and use the correct system libraries.