### PR TITLE
Update tested versions

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -230,8 +230,9 @@ function Test-WindowsVersion {
 
 # 19045: https://www.microsoft.com/en-us/software-download/windows10ISO downloaded on April 25 2023.
 # 20348: the version used by windows-2022 in GH actions
+# 26100: https://www.microsoft.com/en-us/software-download/windows11 downloaded on May 6 2025.
 function Test-TestedOS {
-	$testedVersions = @(19045, 20348)
+	$testedVersions = @(19045, 20348, 26100)
 	try {
 		$osVersion = (Get-CimInstance -class Win32_OperatingSystem).BuildNumber
 		if (-not ($osVersion -in $testedVersions)){

--- a/install.ps1
+++ b/install.ps1
@@ -228,11 +228,10 @@ function Test-WindowsVersion {
 	}
 }
 
-# 17763: the version used by windows-2019 in GH actions
 # 19045: https://www.microsoft.com/en-us/software-download/windows10ISO downloaded on April 25 2023.
 # 20348: the version used by windows-2022 in GH actions
 function Test-TestedOS {
-	$testedVersions = @(17763, 19045, 20348)
+	$testedVersions = @(19045, 20348)
 	try {
 		$osVersion = (Get-CimInstance -class Win32_OperatingSystem).BuildNumber
 		if (-not ($osVersion -in $testedVersions)){


### PR DESCRIPTION
Update the tested versions by:
- Removing `17763`, the version windows-2019 GH runner uses as it has been removed (actions/runner-images#12045) and we do not use it anymore
- Adding 26100, the Windows 11 version FLARE uses for testing.