### PR TITLE
[config] Add cutter

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -23,9 +23,9 @@
     </envs>
     <packages>
         <package name="010editor.vm"/>
-        <package name="angr.vm"/>
         <package name="7zip.vm"/>
         <package name="advanced-installer.vm"/>
+        <package name="angr.vm"/>
         <package name="apimonitor.vm"/>
         <package name="apktool.vm"/>
         <package name="asar.vm"/>
@@ -41,6 +41,7 @@
         <package name="cmder.vm"/>
         <package name="codetrack.vm"/>
         <package name="cryptotester.vm"/>
+        <package name="cutter.vm"/>
         <package name="cyberchef.vm"/>
         <package name="cygwin.vm"/>
         <package name="de4dot-cex.vm"/>


### PR DESCRIPTION
Add cutter disassembler and decompiler to the default configuration. Keep the packages sorted alphabetically.