### PR TITLE
Another option to disable Defender - by using dummy antivirus

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ This section documents the steps to install FLARE-VM. You may also find useful t
       * Non-GPO - Manual: [https://www.maketecheasier.com/permanently-disable-windows-defender-windows-10/](https://www.maketecheasier.com/permanently-disable-windows-defender-windows-10)
       * Non-GPO - Automated: [https://github.com/ionuttbara/windows-defender-remover](https://github.com/ionuttbara/windows-defender-remover)
       * Non-GPO - Semi-Automated (User needs to toggle off Tamper Protection): [https://github.com/AveYo/LeanAndMean/blob/main/ToggleDefender.ps1](https://github.com/AveYo/LeanAndMean/blob/main/ToggleDefender.ps1)
+      * Non-GPO - By installing a dummy antivirus, e.g. [defendnot](https://github.com/es3n1n/defendnot)
 * Take a VM snapshot so you can always revert to a state before the FLARE-VM installation
 * NOTE for IDA Pro: If you are installing IDA Pro via `idapro.vm`, you must place your IDA Pro installer (and optionally, your license file) on the Desktop before running the FLARE-VM installer.
 


### PR DESCRIPTION
Hello!

I found it pretty challenging to permanently disable Defender: on Win 11 25H2, Windows turns of flags in GPO and Registry related to Defender disabling after restart. Even after finding new solutions, we cannot be sure that they will still work afterwards.

This PR introduces new option of disabling Defender by using a dummy antivirus that does nothing. It looks like a easier and manageble way how to disable Defender.