### PR TITLE
 Fix snapshot name typo (remove trailing whitespace)

### DIFF
--- a/virtualbox/README.md
+++ b/virtualbox/README.md
@@ -22,7 +22,7 @@ Snapshots with the following strings in the name (case insensitive) won't be del
 Cleaning FLARE-VM.20240604 🫧 Snapshots to delete:
   Snapshot 1
   wip unpacked
-  JS downloader deobfuscated 
+  JS downloader deobfuscated
   Snapshot 6
   C2 decoded
   Snapshot 5


### PR DESCRIPTION
This PR fixes a typo in the documentation where the snapshot name
JS downloader deobfuscated contained a trailing space.

The trailing whitespace appeared in both the snapshot listing and deletion output, which could cause confusion and break exact string matching when copying or scripting against snapshot names.

Changes

- Removed the trailing space from JS downloader deobfuscated

- Kept all content and formatting unchanged otherwise

Impact
No functional changes — documentation only.
Improves accuracy and prevents subtle copy-paste errors when working with snapshot names.