### PR TITLE
[virtualbox] Support IDA >=9.2 in REMnux

### DIFF
--- a/virtualbox/configs/remnux.yaml
+++ b/virtualbox/configs/remnux.yaml
@@ -6,7 +6,7 @@ SNAPSHOT:
 CMDS:
   - |
     # Install additional useful packages
-    sudo apt-get --assume-yes install libwrap0-dev gdb-multiarch qemu gcc-multilib libcurl4:i386 qemu-user libc6-mips64-mips-cross libc6-mipsel-cross libc6-arm64-cross libc6-armel-cross libc6-armhf-cross libc6-ppc64-cross libc6-powerpc-cross
+    sudo apt-get --assume-yes install libwrap0-dev gdb-multiarch qemu gcc-multilib libcurl4:i386 qemu-user libc6-mips64-mips-cross libc6-mipsel-cross libc6-arm64-cross libc6-armel-cross libc6-armhf-cross libc6-ppc64-cross libc6-powerpc-cross libxcb-cursor0
 
 
   - |


### PR DESCRIPTION
Install `libxcb-cursor0` in REMnux, as otherwise IDA >=9.2 fails with:
```
remnux@remnux:~$ /home/remnux/ida-pro-9.3/ida

qt.qpa.plugin: From 6.5.0, xcb-cursor0 or libxcb-cursor0 is needed to load the Qt xcb platform plugin.

qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.

This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```